### PR TITLE
Straight-forward changes made by 2to3.py means now 2/3 compatible

### DIFF
--- a/BilbyCustomFunctions_Reduction.py
+++ b/BilbyCustomFunctions_Reduction.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.api import *
 from mantid.simpleapi import *
 import csv, math, sys
@@ -63,7 +64,7 @@ def evaluate_files_list(numbers):
     for number in numbers.split(","):
         if "-" in number:
             start, end = number.split("-")
-            nrs = range(int(start), int(end) + 1)
+            nrs = list(range(int(start), int(end) + 1))
             expanded.extend(nrs)
         else:
             expanded.append(int(number))
@@ -125,7 +126,7 @@ def AttenuationCorrection(att_pos, data_before_May_2016):
     """ Bilby has four attenuators; before May 2016 there were only two. Value of the attenuators are hard coded here and being used for the I(Q) scaling in Q1D """
 
     if (data_before_May_2016):
-        print "You stated data have been collected before May, 2016, i.e. using old attenuators. Please double check."
+        print("You stated data have been collected before May, 2016, i.e. using old attenuators. Please double check.")
         if (att_pos == 2.0 or att_pos == 4.0):
             #print "Wrong attenuators value; Either data have been collected after May, 2016, or something is wrong with hdf file"
             #sys.exit()
@@ -181,7 +182,7 @@ def wavelengh_slices(wavelength_intervals, binning_wavelength_ini, wav_delta):
         else:                                                                          # if reminder is greater than 0, to trancate the maximum wavelength in the range
             n = math.floor((wav2 - wav1)/wav_delta)
             max_wave_length = wav1 + n*wav_delta           
-            print ('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length)
+            print(('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length))
 
         # number of wavelength range intervals 
         n = int(n)

--- a/BilbyCustomFunctions_Reduction.py
+++ b/BilbyCustomFunctions_Reduction.py
@@ -182,7 +182,7 @@ def wavelengh_slices(wavelength_intervals, binning_wavelength_ini, wav_delta):
         else:                                                                          # if reminder is greater than 0, to trancate the maximum wavelength in the range
             n = math.floor((wav2 - wav1)/wav_delta)
             max_wave_length = wav1 + n*wav_delta           
-            print(('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length))
+            print('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length)
 
         # number of wavelength range intervals 
         n = int(n)

--- a/IndirectQuickRun.py
+++ b/IndirectQuickRun.py
@@ -453,7 +453,7 @@ class IndirectQuickRun(DataProcessorAlgorithm):
         for run in runs:
             if '-' in run:
                 a, b = run.split('-')
-                run_list.extend(range(int(a), int(b)+1))
+                run_list.extend(list(range(int(a), int(b)+1)))
             else:
                 run_list.append(int(run))
         for idx in run_list:

--- a/SingleCrystal/ReduceDictionary.py
+++ b/SingleCrystal/ReduceDictionary.py
@@ -12,6 +12,7 @@
 # The run numbers themselves may be specified as a comma separated list of
 # individual run numbers, or ranges specified with a colon separator.
 #
+from __future__ import print_function
 def LoadDictionary( *filenames, **kwargs ):
   # create a dictionary to load into
   params_dictionary = kwargs.get("existing", {})
@@ -26,7 +27,7 @@ def LoadDictionary( *filenames, **kwargs ):
       words = line.split()
       # error check the number of values
       if len(words) < 2:
-        print "Syntax Error On Line: " + line
+        print("Syntax Error On Line: " + line)
       # set the value
       else:
         (key, value) = words[0:2]

--- a/SingleCrystal/ReduceSCD_OneRun.py
+++ b/SingleCrystal/ReduceSCD_OneRun.py
@@ -17,6 +17,7 @@
 # NOTE: All of the parameters that the user must specify are listed with
 # instructive comments in the sample configuration file: ReduceSCD.config.
 #
+from __future__ import print_function
 
 #
 # _v1: December 3rd 2013. Mads Joergensen
@@ -45,8 +46,8 @@ sys.path.append("/opt/mantidnightly/bin")
 from mantid.simpleapi import *
 from mantid.api import *
 
-print "API Version"
-print apiVersion()
+print("API Version")
+print(apiVersion())
 
 start_time = time.time()
 
@@ -54,7 +55,7 @@ start_time = time.time()
 # Get the config file name and the run number to process from the command line
 #
 if (len(sys.argv) < 3):
-  print "You MUST give the config file name(s) and run number on the command line"
+  print("You MUST give the config file name(s) and run number on the command line")
   exit(0)
 
 config_files = sys.argv[1:-1]
@@ -134,11 +135,11 @@ else:
       full_name = str(item)
 
   if not full_name.endswith('nxs'):
-    print "Exiting since the data_directory was not specified and"
-    print "findnexus failed for event NeXus file: " + instrument_name + " " + str(run)
+    print("Exiting since the data_directory was not specified and")
+    print("findnexus failed for event NeXus file: " + instrument_name + " " + str(run))
     exit(0)
 
-print "\nProcessing File: " + full_name + " ......\n"
+print("\nProcessing File: " + full_name + " ......\n")
 
 #
 # Name the files to write for this run
@@ -166,14 +167,14 @@ if (calibration_file_1 is not None ) or (calibration_file_2 is not None):
 
 monitor_ws = LoadNexusMonitors( Filename=full_name )
 proton_charge = monitor_ws.getRun().getProtonCharge() * 1000.0  # get proton charge
-print "\n", run, " has integrated proton charge x 1000 of", proton_charge, "\n"
+print("\n", run, " has integrated proton charge x 1000 of", proton_charge, "\n")
 
 integrated_monitor_ws = Integration( InputWorkspace=monitor_ws,
                                      RangeLower=min_monitor_tof, RangeUpper=max_monitor_tof,
                                      StartWorkspaceIndex=monitor_index, EndWorkspaceIndex=monitor_index )
 
 monitor_count = integrated_monitor_ws.dataY(0)[0]
-print "\n", run, " has integrated monitor count", monitor_count, "\n"
+print("\n", run, " has integrated monitor count", monitor_count, "\n")
 
 minVals= "-"+max_Q +",-"+max_Q +",-"+max_Q
 maxVals = max_Q +","+max_Q +","+ max_Q
@@ -227,13 +228,13 @@ SaveIsawPeaks( InputWorkspace=peaks_ws, AppendFile=False,
 # PeakIntegration algorithm.
 #
 if integrate_predicted_peaks:
-  print "PREDICTING peaks to integrate...."
+  print("PREDICTING peaks to integrate....")
   peaks_ws = PredictPeaks( InputWorkspace=peaks_ws,
                 WavelengthMin=min_pred_wl, WavelengthMax=max_pred_wl,
                 MinDSpacing=min_pred_dspacing, MaxDSpacing=max_pred_dspacing,
                 ReflectionCondition='Primitive' )
 else:
-  print "Only integrating FOUND peaks ...."
+  print("Only integrating FOUND peaks ....")
 #
 # Set the monitor counts for all the peaks that will be integrated
 #
@@ -245,9 +246,9 @@ for i in range(num_peaks):
   else:
     peak.setMonitorCount( proton_charge )
 if use_monitor_counts:
-  print '\n*** Beam monitor counts used for scaling.'
+  print('\n*** Beam monitor counts used for scaling.')
 else:
-  print '\n*** Proton charge x 1000 used for scaling.\n'
+  print('\n*** Proton charge x 1000 used for scaling.\n')
 
 if use_sphere_integration:
 #
@@ -332,7 +333,7 @@ SaveIsawPeaks( InputWorkspace=peaks_ws, AppendFile=False,
 # Print warning if user is trying to integrate using the cylindrical method and transorm the cell
 if use_cylindrical_integration:
   if (not cell_type is None) or (not centering is None):
-    print "WARNING: Cylindrical profiles are NOT transformed!!!"
+    print("WARNING: Cylindrical profiles are NOT transformed!!!")
 #
 # If requested, also switch to the specified conventional cell and save the
 # corresponding matrix and integrate file
@@ -352,8 +353,8 @@ else:
     SaveIsawUB( InputWorkspace=peaks_ws, Filename=run_conventional_matrix_file )
 
 end_time = time.time()
-print '\nReduced run ' + str(run) + ' in ' + str(end_time - start_time) + ' sec'
-print 'using config file(s) ' + ", ".join(config_files)
+print('\nReduced run ' + str(run) + ' in ' + str(end_time - start_time) + ' sec')
+print('using config file(s) ' + ", ".join(config_files))
 
 #
 # Try to get this to terminate when run by ReduceSCD_Parallel.py, from NX session

--- a/SingleCrystal/ReduceSCD_Parallel.py
+++ b/SingleCrystal/ReduceSCD_Parallel.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 # File: ReduceSCD_Parallel.py
 #
@@ -44,8 +45,8 @@ sys.path.append("/opt/mantidnightly/bin")
 
 from mantid.simpleapi import *
 
-print "API Version"
-print apiVersion()
+print("API Version")
+print(apiVersion())
 
 start_time = time.time()
 
@@ -60,7 +61,7 @@ class ProcessThread ( threading.Thread ):
       self.command = command
 
    def run ( self ):
-      print 'STARTING PROCESS: ' + self.command
+      print('STARTING PROCESS: ' + self.command)
       os.system( self.command )
 
 # -------------------------------------------------------------------------
@@ -69,7 +70,7 @@ class ProcessThread ( threading.Thread ):
 # Get the config file name from the command line
 #
 if (len(sys.argv) < 2):
-  print "You MUST give the config file name on the command line"
+  print("You MUST give the config file name on the command line")
   exit(0)
 
 config_files = sys.argv[1:]
@@ -143,9 +144,9 @@ while not all_done:
   if len(list) == 0 and len(active_list) == 0 :
     all_done = True
 
-print "\n**************************************************************************************"
-print   "************** Completed Individual Runs, Starting to Combine Results ****************"
-print   "**************************************************************************************\n"
+print("\n**************************************************************************************")
+print("************** Completed Individual Runs, Starting to Combine Results ****************")
+print("**************************************************************************************\n")
 
 #
 # First combine all of the integrated files, by reading the separate files and
@@ -225,7 +226,7 @@ if not use_cylindrical_integration:
 
 if use_cylindrical_integration:
   if (not cell_type is None) or (not centering is None):
-    print "WARNING: Cylindrical profiles are NOT transformed!!!"
+    print("WARNING: Cylindrical profiles are NOT transformed!!!")
   # Combine *.profiles files
   filename = output_directory + '/' + exp_name + '.profiles'
   output = open( filename, 'w' )
@@ -258,11 +259,11 @@ if use_cylindrical_integration:
 
 end_time = time.time()
 
-print "\n**************************************************************************************"
-print   "****************************** DONE PROCESSING ALL RUNS ******************************"
-print   "**************************************************************************************\n"
+print("\n**************************************************************************************")
+print("****************************** DONE PROCESSING ALL RUNS ******************************")
+print("**************************************************************************************\n")
 
-print 'Total time:   ' + str(end_time - start_time) + ' sec'
-print 'Config file: ' + ", ".join(config_files)
-print 'Script file:  ' + reduce_one_run_script + '\n'
-print
+print('Total time:   ' + str(end_time - start_time) + ' sec')
+print('Config file: ' + ", ".join(config_files))
+print('Script file:  ' + reduce_one_run_script + '\n')
+print()

--- a/SingleCrystal/SCDcalib_plot.py
+++ b/SingleCrystal/SCDcalib_plot.py
@@ -3,6 +3,7 @@
 Plot data in SCDcalib.log file from ISAW SCD Calibration.
 A. J. Schultz, September 2015
 """
+from __future__ import print_function
 
 import pylab
 import os
@@ -37,7 +38,7 @@ while True:
     
     title = line
     ID = lineList[-1]
-    print 'ID ', ID
+    print('ID ', ID)
 
     x = []   # Theoretical
     y = []   # Measured
@@ -122,7 +123,7 @@ while True:
     output.write(' %2d  %8d  %8.2f  %8.2f  %8.2f\n' % 
         (IDnum, numPeaks,rmsd_col_mm, rmsd_row_mm, rmsd_combined_mm) )
     
-print '\nAll done!' 
+print('\nAll done!') 
 
 
 

--- a/SingleCrystal/stats_vs_radius.py
+++ b/SingleCrystal/stats_vs_radius.py
@@ -5,6 +5,7 @@
 # NOTE: All of the parameters that the user must specify are listed with 
 # instructive comments in the sample configuration file: ReduceSCD.config.
 #
+from __future__ import print_function
 import os
 import sys
 import pylab
@@ -87,11 +88,11 @@ else:
   full_name = temp_buffer.readline()
   full_name=full_name.strip()
   if not full_name.endswith('nxs'):
-    print "Exiting since the data_directory was not specified and"
-    print "findnexus failed for event NeXus file: " + instrument_name + " " + str(run)
+    print("Exiting since the data_directory was not specified and")
+    print("findnexus failed for event NeXus file: " + instrument_name + " " + str(run))
     exit(0)
 
-print "\nProcessing File: " + full_name + " ......\n"
+print("\nProcessing File: " + full_name + " ......\n")
 
 #
 # Name the files for this run
@@ -111,7 +112,7 @@ for line in Niggli_integrate_file:
     if lineList[0] == '5':
         detnum.append( lineList[1] )
 number_of_detectors = len( detnum )
-print '\nNumber of detectors is %d\n' % number_of_detectors
+print('\nNumber of detectors is %d\n' % number_of_detectors)
 Niggli_integrate_file.close()
 
 # load integrate file and UB matrix into peaks_ws
@@ -129,7 +130,7 @@ event_ws = LoadEventNexus( Filename=full_name,
 # the predicted peaks workspace, so that information can be used by the
 # PeakIntegration algorithm.
 #
-print "PREDICTING peaks to integrate...."
+print("PREDICTING peaks to integrate....")
 peaks_ws = PredictPeaks( InputWorkspace = peaks_ws,
             WavelengthMin = min_pred_wl, WavelengthMax = max_pred_wl,
             MinDSpacing = min_pred_dspacing, MaxDSpacing = max_pred_dspacing, 
@@ -171,7 +172,7 @@ for i in range(num_radius_steps):
     peak_radius = min_peak_radius + (i * radius_step)
     bkg_inner_radius = peak_radius
     bkg_outer_radius = bkg_inner_radius + bkg_width
-    print peak_radius
+    print(peak_radius)
     peaks_ws = IntegratePeaksMD( InputWorkspace=MDEW, PeakRadius=peak_radius,
                   CoordinatesToUse="Q (sample frame)",
               BackgroundOuterRadius=bkg_outer_radius, 
@@ -228,7 +229,7 @@ for i in range(num_radius_steps):
     # Print the results.
     #
     outString = '%10.3f%10d%10d%10d%10d%10d\n' % (peak_radius, sum, sig2, sig3, sig5, sig10)
-    print outString
+    print(outString)
     output.write(outString)
 
     input.close()
@@ -243,8 +244,8 @@ for i in range(4):
 os.remove( temp_integrate_file )                 
 output.close()
 end_time = time.time()
-print '\nReduced run ' + str(run) + ' in ' + str(end_time - start_time) + ' sec'
-print 'using config file ' + config_file_name 
+print('\nReduced run ' + str(run) + ' in ' + str(end_time - start_time) + ' sec')
+print('using config file ' + config_file_name) 
 
 #
 # Plot the results
@@ -293,7 +294,7 @@ pylab.savefig( plotTitle )   # plot saved
 pylab.ion()                  # turn on interactive mode
 pylab.show()
 
-raw_input('Type RETURN to continue.')
+input('Type RETURN to continue.')
 
 #
 # Plot stats vs radius for each detector individually
@@ -340,6 +341,6 @@ ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
 pylab.savefig( plotTitle )   # plot saved
 pylab.show()
 
-raw_input('Type RETURN to exit.')
+input('Type RETURN to exit.')
 sys.exit(0)
 

--- a/SingleCrystal/stats_vs_time.py
+++ b/SingleCrystal/stats_vs_time.py
@@ -5,6 +5,7 @@
 # NOTE: All of the parameters that the user must specify are listed with 
 # instructive comments in the sample configuration file: ReduceSCD.config.
 #
+from __future__ import print_function
 import os
 import sys
 import pylab
@@ -66,11 +67,11 @@ else:
   full_name = temp_buffer.readline()
   full_name=full_name.strip()
   if not full_name.endswith('nxs'):
-    print "Exiting since the data_directory was not specified and"
-    print "findnexus failed for event NeXus file: " + instrument_name + " " + str(run)
+    print("Exiting since the data_directory was not specified and")
+    print("findnexus failed for event NeXus file: " + instrument_name + " " + str(run))
     exit(0)
 
-print "\nProcessing File: " + full_name + " ......\n"
+print("\nProcessing File: " + full_name + " ......\n")
 
 # Name the files for this run
 run_niggli_matrix_file = output_directory + "/" + run + "_Niggli.mat"
@@ -87,8 +88,8 @@ total_time = event_ws.run()['duration'].value
 
 number_of_steps = ( math.log(total_time) - math.log(60.0) ) / math.log(MultiplierBase)
 number_of_steps = int(number_of_steps) + 1
-print '\nnumber_of_steps = ', number_of_steps
-print ''
+print('\nnumber_of_steps = ', number_of_steps)
+print('')
 # ln_MultiplierBase = ( math.log(total_time) - math.log(60.0) ) / 10.0
 # MultiplierBase = math.exp(ln_MultiplierBase)
 # print 'For 10 steps, MultiplierBase =', MultiplierBase
@@ -96,7 +97,7 @@ print ''
 # Get complete list of peaks to be integrated and load the UB matrix into
 # the predicted peaks workspace, so that information can be used by the
 # PeakIntegration algorithm.
-print "PREDICTING peaks to integrate...."
+print("PREDICTING peaks to integrate....")
 peaks_ws = PredictPeaks( InputWorkspace = peaks_ws,
         WavelengthMin = min_pred_wl, WavelengthMax = max_pred_wl,
         MinDSpacing = min_pred_dspacing, MaxDSpacing = max_pred_dspacing, 
@@ -186,8 +187,8 @@ while True:
     # Print the results.
     #
     outString = '%10.1f%10d%10d%10d%10d%10d\n' % (time_stop, sum, sig2, sig3, sig5, sig10)
-    print ''
-    print outString
+    print('')
+    print(outString)
     output.write(outString)
     x.append( time_stop )
     ytotal.append( sum )
@@ -204,7 +205,7 @@ while True:
 os.remove( temp_integrate_file )                 
 output.close()
 end_time = time.time()
-print '\nAnalyzed run ' + str(run) + ' in ' + str(end_time - start_time) + ' sec'
+print('\nAnalyzed run ' + str(run) + ' in ' + str(end_time - start_time) + ' sec')
 
 #
 # Plot the results
@@ -227,5 +228,5 @@ pylab.savefig( plotTitle )   # plot saved
 # pylab.ion()                  # turn on interactive mode
 pylab.show()
 
-raw_input('Type RETURN to continue.')
+input('Type RETURN to continue.')
 sys.exit(0)

--- a/direct_inelastic/ISIS/CrystalAlignment/Check_alignement.py
+++ b/direct_inelastic/ISIS/CrystalAlignment/Check_alignement.py
@@ -1,4 +1,5 @@
 # Load single crystl white beam data from MERLIN - Sr3 Fe2 O7 sample
+from __future__ import print_function
 
 LoadRaw(Filename='MER16000.raw', OutputWorkspace='MER16000')
 
@@ -12,10 +13,10 @@ u=UnitCell(a,b,c,90,90,90)
 
 # Print d spacing or angle between reflections - examples:
 
-print u.d(1,1,0)
-print u.d(1,0,0)
+print(u.d(1,1,0))
+print(u.d(1,0,0))
 
-print u.recAngle(1,1,0,1,0,0)
+print(u.recAngle(1,1,0,1,0,0))
 
 # If you want to convert to d spacing : 
 #ConvertUnits(InputWorkspace='MER16000', OutputWorkspace='MER16000d', Target='dSpacing')
@@ -63,7 +64,7 @@ rotmat = np.matrix([ [np.cos(ang), -np.sin(ang), 0], [np.sin(ang), np.cos(ang), 
 UBinv = np.linalg.inv(rotmat * mantid2horace * UB)
 uVector = UBinv[:,0] / np.linalg.norm(UBinv[:,0])
 vVector = UBinv[:,1] / np.linalg.norm(UBinv[:,1])
-print uVector,vVector
+print(uVector,vVector)
 # To get rotation angles from this w.r.t. some defined u,v vectors, use the crystal_pars_correct() function in Horace, e.g.:
 #[~, ~, dpsi, gl, gs] = crystal_pars_correct(uFromMantid, vFromMantid, alatt, angdeg, 0, 0, 0, 0, eye(3), uDesired, vDesired)
 

--- a/direct_inelastic/ISIS/qtiGenie/DgFuncs.py
+++ b/direct_inelastic/ISIS/qtiGenie/DgFuncs.py
@@ -1,14 +1,15 @@
+from __future__ import print_function
 from mantid.simpleapi import *
 from numpy import *
 try:
 	from scipy import signal
 except:
-	print 'Scipy module not in scope'
+	print('Scipy module not in scope')
 	
 #uses the new api all input workpsaces are expected to have |Q| along X and Energy Transfer along Y
 def gofe(wkspin,T,dbwfac):
 	dat=mtd[wkspin]
-	print 'correcting workspace' , dat.name(),' to be the pdos with T=',T,'K and |U^2| as ',dbwfac 
+	print('correcting workspace' , dat.name(),' to be the pdos with T=',T,'K and |U^2| as ',dbwfac) 
 	x=dat.extractX()
 		
 	y=dat.extractY()
@@ -50,7 +51,7 @@ def gofe(wkspin,T,dbwfac):
 
 def byE(wkspin):
 	dat=mtd[wkspin]
-	print 'Flattening workspace' , dat.name() 
+	print('Flattening workspace' , dat.name()) 
 	x=dat.extractX()
 		
 	y=dat.extractY()
@@ -75,7 +76,7 @@ def byE(wkspin):
 def gaussSmooth(wkspin,n):
 	ReplaceSpecialValues(InputWorkspace=wkspin,OutputWorkspace=wkspin,NaNValue='0',InfinityValue='0')
 	dat=mtd[wkspin]
-	print 'Smoothing workspace' , dat.name(), 'by Gaussian convolution ',n,' times'
+	print('Smoothing workspace' , dat.name(), 'by Gaussian convolution ',n,' times')
 	
 	x=dat.extractX()	
 	y=dat.extractY()
@@ -120,7 +121,7 @@ def blur_image(im, n, ny=None) :
 
 def bose(wkspin,T):
 	dat=mtd[wkspin]
-	print 'correcting workspace ' , dat.name(),' by the Bose Factor with T=',T,'K' 
+	print('correcting workspace ' , dat.name(),' by the Bose Factor with T=',T,'K') 
 	x=dat.extractX()
 		
 	y=dat.extractY()
@@ -145,7 +146,7 @@ def bose(wkspin,T):
 	
 def DetailBalance(wkspin,T):
 	dat=mtd[wkspin]
-	print 'correcting workspace for DB' , dat.name(),' with T=',T,'K' 
+	print('correcting workspace for DB' , dat.name(),' with T=',T,'K') 
 	x=dat.extractX()
 		
 	y=dat.extractY()
@@ -169,7 +170,7 @@ def DetailBalance(wkspin,T):
 
 def perCm(wkspin):
 	dat=mtd[wkspin]
-	print 'converting energy units to per cm' 
+	print('converting energy units to per cm') 
 	x=dat.extractX()
 		
 	y=dat.extractY()
@@ -186,7 +187,7 @@ def perCm(wkspin):
 	return wkspOut
 def meV(wkspin):
 	dat=mtd[wkspin]
-	print 'converting energy units to meV' 
+	print('converting energy units to meV') 
 	x=dat.extractX()
 		
 	y=dat.extractY()

--- a/direct_inelastic/ISIS/qtiGenie/PySlice.py
+++ b/direct_inelastic/ISIS/qtiGenie/PySlice.py
@@ -1,4 +1,5 @@
 #from utils import *
+from __future__ import print_function
 from mantid.simpleapi import *
 from mantid.kernel import funcreturns
 from mantidplot import *
@@ -77,7 +78,7 @@ def sqw(wksp_in,qbin):
 		Transpose(InputWorkspace=wksp_out,OutputWorkspace=wksp_out)
 		return mtd[wksp_out]
 	except:
-		print 'no output workpsace defined'
+		print('no output workpsace defined')
 
 	
 def cut(wksp,min,max,**kwargs):
@@ -90,7 +91,7 @@ def cut(wksp,min,max,**kwargs):
 	'''
 	global active_layer, graph
 	
-	if kwargs.has_key('along') and kwargs.get('along')=='e' or kwargs.has_key('along') and kwargs.get('along')=='E':
+	if 'along' in kwargs and kwargs.get('along')=='e' or 'along' in kwargs and kwargs.get('along')=='E':
 	
 		# get the x vector which in principle is Q
 		xvec=wksp.readX(0)
@@ -104,7 +105,7 @@ def cut(wksp,min,max,**kwargs):
 		numpix=maxel-minel
 		out=numpy.zeros(wksp.getNumberHistograms())
 		outerr=numpy.zeros(wksp.getNumberHistograms())
-		print numpix
+		print(numpix)
 		for i in range(wksp.getNumberHistograms()):
 			out[i]=numpy.sum(wksp.readY(i)[minel:maxel])/numpix
 			
@@ -121,13 +122,13 @@ def cut(wksp,min,max,**kwargs):
 		labely="Intensity arb. units"
 		labelx="Energy Transfer meV"
 		title='Cut from '+str(wksp)+' between '+str(min)+' and '+str(max)+' invA'
-		if kwargs.has_key('over') and kwargs.get('over')==True:
+		if 'over' in kwargs and kwargs.get('over')==True:
 			
 			plotOverFromQtiTable(table,labelx,labely,title)
 		else:
 			plotFromQtiTable(table,labelx,labely,title)
 	
-	if kwargs.has_key('along') and kwargs.get('along')=='q' or kwargs.has_key('along') and kwargs.get('along')=='Q':
+	if 'along' in kwargs and kwargs.get('along')=='q' or 'along' in kwargs and kwargs.get('along')=='Q':
 		wksp=transpose(wksp)
 		# get the x vector which in principle is Q
 		xvec=wksp.readX(0)
@@ -141,7 +142,7 @@ def cut(wksp,min,max,**kwargs):
 		numpix=maxel-minel
 		out=numpy.zeros(wksp.getNumberHistograms())
 		outerr=numpy.zeros(wksp.getNumberHistograms())
-		print numpix
+		print(numpix)
 		for i in range(wksp.getNumberHistograms()):
 			out[i]=numpy.sum(wksp.readY(i)[minel:maxel])/numpix
 			
@@ -159,7 +160,7 @@ def cut(wksp,min,max,**kwargs):
 		labely="Intensity arb. units"
 		labelx="Momentum Transfer |Q|"
 		title='Cut from '+str(wksp)+' between '+str(min)+' and '+str(max)+' meV'
-		if kwargs.has_key('over') and kwargs.get('over')==True:
+		if 'over' in kwargs and kwargs.get('over')==True:
 			
 			plotOverFromQtiTable(table,labelx,labely,title)
 		else:

--- a/direct_inelastic/ISIS/qtiGenie/PySlice2.py
+++ b/direct_inelastic/ISIS/qtiGenie/PySlice2.py
@@ -1,4 +1,5 @@
 #from DirectEnergyConversion import *
+from __future__ import print_function
 import time as time
 try:
     import dgreduce    
@@ -36,8 +37,8 @@ class data2D:
 		wksp_in=self.wksp_name
 		wksp_new_name=wksp_in.getName()+'_SQW'
 		wksp_newDisp=wksp_new_name+'display'
-		if kwargs.has_key('fast'):
-			print 'Using fast rebin'
+		if 'fast' in kwargs:
+			print('Using fast rebin')
 			tmpdat=self.sqwfast(self.wksp_name,qbin)
 			Transpose(InputWorkspace='tmpdat',OutputWorkspace=wksp_newDisp)
 			RenameWorkspace(InputWorkspace=tmpdat,OutputWorkspace=wksp_new_name)
@@ -45,7 +46,7 @@ class data2D:
 			self.data=mtd[wksp_new_name]
 			self.data_disp=mtd[wksp_newDisp]
 		else:
-			print 'Using intersecting area rebin'
+			print('Using intersecting area rebin')
 			#need a method to get max and min angles
 			tmpdat=self.sqw(self.wksp_name,qbin)
 			
@@ -78,7 +79,7 @@ class data2D:
 		except:
 			if n<=2:
 				n=3
-			print "Failure of Gaussian smooth revert to averaging"	
+			print("Failure of Gaussian smooth revert to averaging")	
 			SmoothData(InputWorkspace=self.data_disp,OutputWorkspace=self.data_disp,NPoints=n)
 			if len(args)==1:
 				self.display()
@@ -164,9 +165,9 @@ class data2D:
 		try:
 			n,r=funcreturns.lhs_info('both')
 			name=r[0]
-			if kwargs.has_key('shoelace'):
-				if kwargs.has_key('over'):
-					if kwargs.has_key('Handle'):
+			if 'shoelace' in kwargs:
+				if 'over' in kwargs:
+					if 'Handle' in kwargs:
 						fighandle=kwargs.get('Handle')
 						self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='e',over=True,cutName=name,shoelace=True,Handle=fighandle)
 					else:
@@ -174,8 +175,8 @@ class data2D:
 				else:
 					self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='e',cutName=name,shoelace=True)
 			else:
-				if kwargs.has_key('over'):
-					if kwargs.has_key('Handle'):
+				if 'over' in kwargs:
+					if 'Handle' in kwargs:
 						fighandle=kwargs.get('Handle')
 						self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='e',over=True,cutName=name,Handle=fighandle)
 					else:
@@ -183,9 +184,9 @@ class data2D:
 				else:
 					self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='e',cutName=name)
 		except:		
-			if kwargs.has_key('shoelace'):
-				if kwargs.has_key('over'):
-					if kwargs.has_key('Handle'):
+			if 'shoelace' in kwargs:
+				if 'over' in kwargs:
+					if 'Handle' in kwargs:
 						fighandle=kwargs.get('Handle')
 						self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='e',over=True,shoelace=True,Handle=fighandle)
 					else:
@@ -193,8 +194,8 @@ class data2D:
 				else:
 					self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='e',shoelace=True)
 			else:
-				if kwargs.has_key('over'):
-					if kwargs.has_key('Handle'):
+				if 'over' in kwargs:
+					if 'Handle' in kwargs:
 						fighandle=kwargs.get('Handle')
 						self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='e',over=True,Handle=fighandle)
 					else:
@@ -212,9 +213,9 @@ class data2D:
 		try:
 			n,r=funcreturns.lhs_info('both')
 			name=r[0]
-			if kwargs.has_key('shoelace'):
-				if kwargs.has_key('over'):
-					if kwargs.has_key('Handle'):
+			if 'shoelace' in kwargs:
+				if 'over' in kwargs:
+					if 'Handle' in kwargs:
 						fighandle=kwargs.get_key('Handle')
 						self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='q',over=True,cutName=name,shoelace=True,Handle=fighandle)
 					else:
@@ -222,8 +223,8 @@ class data2D:
 				else:
 					self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='q',cutName=name,shoelace=True)
 			else:
-				if kwargs.has_key('over'):
-					if kwargs.has_key('Handle'):
+				if 'over' in kwargs:
+					if 'Handle' in kwargs:
 						fighandle=kwargs.get('Handle')
 						self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='q',over=True,cutName=name,Handle=fighandle)
 					else:
@@ -231,9 +232,9 @@ class data2D:
 				else:
 					self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='q',cutName=name)
 		except:		
-			if kwargs.has_key('shoelace'):
-				if kwargs.has_key('over'):
-					if kwargs.has_key('Handle'):
+			if 'shoelace' in kwargs:
+				if 'over' in kwargs:
+					if 'Handle' in kwargs:
 						fighandle=kwargs.get('Handle')
 						self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='q',over=True,shoelace=True,Handle=fighandle)
 					else:
@@ -241,8 +242,8 @@ class data2D:
 				else:
 					self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='q',shoelace=True)
 			else:
-				if kwargs.has_key('over'):
-					if kwargs.has_key('Handle'):
+				if 'over' in kwargs:
+					if 'Handle' in kwargs:
 						fighandle=kwargs.get('Handle')
 						self.cut(self.data,intmin,intmax,cutmin,delcut,cutmax,along='q',over=True,Handle=fighandle)
 					else:
@@ -256,14 +257,14 @@ class data2D:
 		#		   wkspIn= input data
 		
 		#deal with the call type and where to get the output workspace name from
-		if kwargs.has_key('wkspout'):
+		if 'wkspout' in kwargs:
 			cut_name=kwargs.get('wkspout')
 		else:
 			n,r=funcreturns.lhs_info('both')
 			cut_name=r[0]
 		
 		if direction == 'x':
-			if kwargs.has_key('wkspIn'):
+			if 'wkspIn' in kwargs:
 				wkspinName=kwargs.get('wkspIn')	
 				Rebin2D(InputWorkspace=wkspinName,OutputWorkspace=cut_name,Axis1Binning=str(minX)+','+str(delX)+','+str(maxX),Axis2Binning=str(intMin)+','+str(intMax-intMin)+','+str(intMax),UseFractionalArea='1' )
 				
@@ -271,7 +272,7 @@ class data2D:
 				Rebin2D(InputWorkspace=self.data,OutputWorkspace=cut_name,Axis1Binning=str(minX)+','+str(delX)+','+str(maxX),Axis2Binning=str(intMin)+','+str(intMax-intMin)+','+str(intMax),UseFractionalArea='1' )
 		
 		if direction == 'y':
-			if kwargs.has_key('wkspin'):
+			if 'wkspin' in kwargs:
 				wkspinName=kwargs.get('wkspin')	
 				Rebin2D(InputWorkspace=wkspinName,OutputWorkspace=cut_name,Axis1Binning=str(intMin)+','+str(intMax-intMin)+','+str(intMax),Axis2Binning=str(minX)+','+str(delX)+','+str(maxX),UseFractionalArea='1')
 				Transpose(InputWorkspace=cut_name,OutputWorkspace=cut_name)
@@ -327,8 +328,8 @@ class data2D:
 	
 	def display(self,*args):
 		data=self.data_disp	
-		print type(data)
-		print self.wksp_name.getName()
+		print(type(data))
+		print(self.wksp_name.getName())
 		#dat=self.data.importMatrixWorkspace().plotGraph2D()
 		#out=importMatrixWorkspace(data.getName())
 		out=importMatrixWorkspace(self.wksp_name.getName()+'_SQWdisplay')
@@ -392,7 +393,7 @@ class data2D:
 			SofQW(wksp_in,OutputWorkspace=wksp_out,QAxisBinning=qbin,EMode="Direct",EFixed=str(ei))
 			return mtd[wksp_out]
 		except:
-			print 'no output workpsace defined'
+			print('no output workpsace defined')
 
 	def integrate(self,qmin,qmax,emin,emax):
 		'''Integrate a region of S(q,w)
@@ -405,7 +406,7 @@ class data2D:
 		value=zeros(2)
 		value[0]=tmpWksp.extractY()[0]
 		value[1]=tmpWksp.extractE()[0]
-		print 'Integral between ',qmin,' to ',qmax,' A^-1 and ',emin,'to ',emax,'mev =',value[0],'+/-',value[1]
+		print('Integral between ',qmin,' to ',qmax,' A^-1 and ',emin,'to ',emax,'mev =',value[0],'+/-',value[1])
 		DeleteWorkspace('tmpWksp')
 		return value
 		
@@ -421,7 +422,7 @@ class data2D:
 		y=tmpWksp.extractY()[0]
 		Err=tmpWksp.extractE()[0]
 		value=(Err/y)*100
-		print 'percent error in bin ',qmin,' to ',qmax,' A^-1 and ',emin,'to ',emax,'mev =',value[0]
+		print('percent error in bin ',qmin,' to ',qmax,' A^-1 and ',emin,'to ',emax,'mev =',value[0])
 		DeleteWorkspace('tmpWksp')
 		return value[0]
 	
@@ -434,15 +435,15 @@ class data2D:
 		along=e
 		'''
 		
-		if kwargs.has_key('along') and kwargs.get('along')=='q' or kwargs.has_key('along') and kwargs.get('along')=='Q':
+		if 'along' in kwargs and kwargs.get('along')=='q' or 'along' in kwargs and kwargs.get('along')=='Q':
 		
 			#axis2 is |Q|, axis1 is energy transfer
-			if kwargs.has_key('cutName'):
+			if 'cutName' in kwargs:
 				cut_name=kwargs.get('cutName')
 			else:
 				cut_name='Cut from '+str(self.wksp_name)+' integrating '+str(intMin)+' and '+str(intMax)+' meV'
 			
-			if kwargs.has_key('shoelace'):
+			if 'shoelace' in kwargs:
 				Rebin2D(InputWorkspace=wksp,OutputWorkspace=cut_name,Axis1Binning=str(intMin)+','+str(intMax-intMin)+','+str(intMax),Axis2Binning=str(minX)+','+str(delX)+','+str(maxX),UseFractionalArea='1')
 			else:
 				Rebin2D(InputWorkspace=wksp,OutputWorkspace=cut_name,Axis1Binning=str(intMin)+','+str(intMax-intMin)+','+str(intMax),Axis2Binning=str(minX)+','+str(delX)+','+str(maxX))
@@ -450,8 +451,8 @@ class data2D:
 			Transpose(InputWorkspace=cut_name,OutputWorkspace=cut_name)
 
 			
-			if kwargs.has_key('over'):
-				if kwargs.has_key('Handle'):
+			if 'over' in kwargs:
+				if 'Handle' in kwargs:
 					fighandle=kwargs.get('Handle')
 					lgr=fighandle# handle of the fig from the dict to plot over onto
 					self.fignum=self.fignum+1
@@ -461,7 +462,7 @@ class data2D:
 					mergePlots(graph,lgr)
 				else:				
 					plotover=self.fignum #assumes that the plot over will be the last plotted figure
-					print plotover
+					print(plotover)
 					lgr=self.figure_dict.get(self.fignum)[1]#gets the handle of the last fig from the dict
 					
 					self.fignum=self.fignum+1
@@ -478,22 +479,22 @@ class data2D:
 				
 				active_layer = graph.activeLayer()
 			
-		if kwargs.has_key('along') and kwargs.get('along')=='e' or kwargs.has_key('along') and kwargs.get('along')=='E':
-			if kwargs.has_key('cutName'):
+		if 'along' in kwargs and kwargs.get('along')=='e' or 'along' in kwargs and kwargs.get('along')=='E':
+			if 'cutName' in kwargs:
 				cut_name=kwargs.get('cutName')
 			else:
 				cut_name='Cut from '+str(self.wksp_name)+' integrating '+str(intMin)+' and '+str(intMax)+' A^-1'
 			
 			#axis2 is |Q|, axis1 is energy transfer
 			
-			if kwargs.has_key('shoelace'):
+			if 'shoelace' in kwargs:
 				Rebin2D(InputWorkspace=wksp,OutputWorkspace=cut_name,Axis1Binning=str(minX)+','+str(delX)+','+str(maxX),Axis2Binning=str(intMin)+','+str(intMax-intMin)+','+str(intMax),UseFractionalArea='1' )
 			else:
 				Rebin2D(InputWorkspace=wksp,OutputWorkspace=cut_name,Axis1Binning=str(minX)+','+str(delX)+','+str(maxX),Axis2Binning=str(intMin)+','+str(intMax-intMin)+','+str(intMax))
 			ReplaceSpecialValues(InputWorkspace=cut_name,OutputWorkspace=cut_name,NaNValue='0',InfinityValue='0')
 			
-			if kwargs.has_key('over'):
-				if kwargs.has_key('Handle'):
+			if 'over' in kwargs:
+				if 'Handle' in kwargs:
 					fighandle=kwargs.get('Handle')
 					lgr=fighandle# handle of the fig from the dict to plot over onto
 					self.fignum=self.fignum+1
@@ -503,7 +504,7 @@ class data2D:
 					mergePlots(graph,lgr)
 				else:				
 					plotover=self.fignum #assumes that the plot over will be the last plotted figure
-					print plotover
+					print(plotover)
 					lgr=self.figure_dict.get(self.fignum)[1]#gets the handle of the last fig from the dict
 					
 					self.fignum=self.fignum+1
@@ -519,7 +520,7 @@ class data2D:
 				self.figure_dict.setdefault(self.fignum,plot)
 				
 				active_layer = graph.activeLayer()
-		if kwargs.has_key('cutName'):
+		if 'cutName' in kwargs:
 			return mtd[kwargs.get('cutName')]
 		else:
 			return

--- a/direct_inelastic/ISIS/qtiGenie/PysliceGui.py
+++ b/direct_inelastic/ISIS/qtiGenie/PysliceGui.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import sys
 from PySliceUI2 import Ui_MainWindow
@@ -114,7 +115,7 @@ class MainWindow(QtGui.QMainWindow):
 	def setInst(self):
 	
 		self.inst=str(self.ui.InstName.currentText())
-		print self.inst 
+		print(self.inst) 
 		
 		if self.inst=='Mari':
 			self.shortname='MAR'
@@ -124,7 +125,7 @@ class MainWindow(QtGui.QMainWindow):
 	def setNormMethod(self):
 	
 		self.Normalisation=str(self.ui.NormMethod.currentText())
-		print self.Normalisation
+		print(self.Normalisation)
 		
 		
 	def BkgSwitchOn(self):
@@ -132,30 +133,30 @@ class MainWindow(QtGui.QMainWindow):
 		if self.BkgSwitch==False:
 			self.BkgSwitch =True
 			self.BkgdRange=[]
-			print 'Background subtraction on'
+			print('Background subtraction on')
 		else:
 			self.BkgSwitch =False
 			self.BkgdRange=[]
-			print 'Background subtraction off'
+			print('Background subtraction off')
 	
 	def sumRunsOn(self):
 	
 		if self.sumRunsCheck==False:
 			self.sumRunsCheck =True
-			print 'Reduction will sum runs'
+			print('Reduction will sum runs')
 		else:
 			self.sumRunsCheck =False
-			print 'Reduction will not sum runs'
+			print('Reduction will not sum runs')
 			
 	def AutoEiOn(self):
 	
 		if self.AutoEi==False:
 			self.AutoEi =True
-			print 'AutoEi on'
+			print('AutoEi on')
 		else:
 			self.AutoEi =False
 			self.EiVal=double(self.ui.EiGuess.text())
-			print 'AutoEi off: Ei guess is', str(self.EiVal),' meV'
+			print('AutoEi off: Ei guess is', str(self.EiVal),' meV')
 			
 	
 	def FixEiOn(self):
@@ -163,10 +164,10 @@ class MainWindow(QtGui.QMainWindow):
 		if self.FixEi==False:
 			self.FixEi =True
 			self.EiVal=double(self.ui.EiGuess.text())
-			print 'FixEi on set to :', str(self.EiVal),' meV'
+			print('FixEi on set to :', str(self.EiVal),' meV')
 		else:
 			self.FixEi =False
-			print 'FixEi off'
+			print('FixEi off')
 	
 	
 	def MonitorSpec(self):
@@ -174,19 +175,19 @@ class MainWindow(QtGui.QMainWindow):
 		if self.MonitorSpec==False:
 			self.MonitorSpec =True
 			self.MonitorSpectrumNumber=int(self.ui.MonSpecNumber.text())
-			print 'Monitor spectrum set to :', str(self.MonitorSpectrumNumber)
+			print('Monitor spectrum set to :', str(self.MonitorSpectrumNumber))
 		else:
 			self.MonitorSpec =False
-			print 'Monitor spectrum set to default'
+			print('Monitor spectrum set to default')
 	
 	def AbsNormOn(self):
 	
 		if self.AbsNormStatus==False:
 			self.AbsNormStatus =True
-			print 'Absolute Normalisation on'
+			print('Absolute Normalisation on')
 		else:
 			self.AbsNormStatus =False
-			print 'Absolute Normalisation off'
+			print('Absolute Normalisation off')
 	def getRuns(self):
 		WB=str(self.ui.DetVanNum.text())
  		Run=str(self.ui.RunNum.text())
@@ -200,7 +201,7 @@ class MainWindow(QtGui.QMainWindow):
  			#case for a colon separated list
  			#generate a list of strings from range
  			tmp=Run.split(':')
- 			Runs=range(int(tmp[0]),int(tmp[1])+1)
+ 			Runs=list(range(int(tmp[0]),int(tmp[1])+1))
  		
  		if len(Run.split(','))==1 & len(Run.split(':'))==1:
 			if Run=='current':
@@ -212,7 +213,7 @@ class MainWindow(QtGui.QMainWindow):
  				Runs=[1]
  				Runs[0]=tmp
 
- 		print Runs, type(Run)
+ 		print(Runs, type(Run))
  		return WB,Runs
  	
  	def Reduce(self):
@@ -227,7 +228,7 @@ class MainWindow(QtGui.QMainWindow):
  		#absolute normalisation will be preformed
  		#try:
 		WB,Runs=self.getRuns()
-		print Runs, type(Runs)
+		print(Runs, type(Runs))
 		
 		iliad_setup(self.shortname)
 		mapfile=str(self.ui.mapfile.text())
@@ -303,7 +304,7 @@ class MainWindow(QtGui.QMainWindow):
  	
  		#try:
 		WB,Runs=self.getRuns()
-		print Runs, type(Runs)
+		print(Runs, type(Runs))
 		
 		if Runs=='current':
 			#get live data
@@ -366,7 +367,7 @@ class MainWindow(QtGui.QMainWindow):
 		#	self.ui.ReduceOutput.addItem(String)
 			
  	def setwksp(self):
- 		print 'high'
+ 		print('high')
  	
  	def removeWksp(self):
  		tmp=self.ui.wkspList.selectedItems()[0].text()
@@ -390,7 +391,7 @@ class MainWindow(QtGui.QMainWindow):
  		temp=float(self.ui.Temperature.text())
  		
  		if temp >=0.0:
- 			print 'Correct for Bose factor'
+ 			print('Correct for Bose factor')
  			tmp=self.ui.wkspList.selectedItems()[0].text()
  			row= self.ui.wkspList.currentRow()
  			self.ui.wkspList.takeItem(row)
@@ -401,7 +402,7 @@ class MainWindow(QtGui.QMainWindow):
 			data=self.data_dict.get(str(self.selectedWksp))
 			data.boseFac(temp)
  		else:
- 			print 'Enter temperature in kelvin for run'
+ 			print('Enter temperature in kelvin for run')
  			
  		
  	def pdos(self):
@@ -409,7 +410,7 @@ class MainWindow(QtGui.QMainWindow):
  		dbwfac=float(self.ui.DBWFac.text())
  		
  		if temp >=0.0:
- 			print 'Calculate Density of States'
+ 			print('Calculate Density of States')
  			tmp=self.ui.wkspList.selectedItems()[0].text()
  			row= self.ui.wkspList.currentRow()
  			self.ui.wkspList.takeItem(row)
@@ -419,7 +420,7 @@ class MainWindow(QtGui.QMainWindow):
 			data=self.data_dict.get(str(self.selectedWksp))
 			data.gofe(temp,dbwfac)	
 		else:
- 			print 'Enter temperature in kelvin for run'
+ 			print('Enter temperature in kelvin for run')
  			
  	def refreshlist(self): 
 		self.ui.WkspIn.clear() 
@@ -439,12 +440,12 @@ class MainWindow(QtGui.QMainWindow):
 			tmp=mtd[allNames[i]]
 			try:
 				if tmp.getAxis(0).getUnit().caption() == 'Energy transfer' and tmp.getName().find('SQW')==-1:
-					print allNames[i] +' has units of energy transfer'
+					print(allNames[i] +' has units of energy transfer')
 					if tmp.getNumberHistograms() > 1:
 						self.ui.WkspIn.insertItem(iter,allNames[i])
 					iter=iter+1
 			except:
-				print allNames[i]  +' is not a matrix workspace'
+				print(allNames[i]  +' is not a matrix workspace')
 
 		
 		
@@ -488,9 +489,9 @@ class MainWindow(QtGui.QMainWindow):
 			self.selectedWksp = tmp.split(':')[0]
 			data=self.data_dict.get(str(self.selectedWksp))
 		except:
-			print 'select workspace to plot from'
+			print('select workspace to plot from')
 		if dir=='E':
-			print 'Cut along E'
+			print('Cut along E')
 			self.fignum=self.fignum+1
 			data.ECut(self.intMin,self.intMax,self.cutMin,self.delta,self.cutMax,shoelace=True)
 			entry=data.figure_dict.get(data.fignum)
@@ -505,7 +506,7 @@ class MainWindow(QtGui.QMainWindow):
 			self.ui.FigureList.addItem(string)
 			
 		if dir =='|Q|':
-			print 'Cut along |Q|'
+			print('Cut along |Q|')
 			self.fignum=self.fignum+1
 			data.QCut(self.intMin,self.intMax,self.cutMin,self.delta,self.cutMax,shoelace=True)
 			entry=data.figure_dict.get(data.fignum)
@@ -550,9 +551,9 @@ class MainWindow(QtGui.QMainWindow):
 			#print self.masterFigureDict
 			#print figHandle
 		except:
-			print 'Select both workspace to plot from and figure to plot onto'
+			print('Select both workspace to plot from and figure to plot onto')
 		if dir=='E':
-			print 'Plot over along E'
+			print('Plot over along E')
 			
 			data.ECut(self.intMin,self.intMax,self.cutMin,self.delta,self.cutMax,over=True,Handle=figHandle,shoelace=True)
 			
@@ -565,7 +566,7 @@ class MainWindow(QtGui.QMainWindow):
 			self.masterFigureDict.setdefault(int(self.selectedFig),entry)
 			
 		if dir =='|Q|':
-			print 'Plot Over along |Q|'
+			print('Plot Over along |Q|')
 			data.QCut(self.intMin,self.intMax,self.cutMin,self.delta,self.cutMax,over=True,Handle=figHandle,shoelace=True)
 			
 			entry=data.figure_dict.get(data.fignum)
@@ -610,14 +611,14 @@ class MainWindow(QtGui.QMainWindow):
 				data.display()
 				
 		except:
-			print 'Select data to display'
+			print('Select data to display')
 				
 	def calcProj(self):
 	
 		wkspName=str(self.ui.WkspIn.currentText())
 		
 		if self.data_dict.get(str(wkspName)) != None:
-			print 'S(qw) data from ',wkspName,'exists, deleting existing instance'
+			print('S(qw) data from ',wkspName,'exists, deleting existing instance')
 			tmpdata=self.data_dict.get(str(wkspName))
  			DeleteWorkspace(tmpdata.data)
  			DeleteWorkspace(tmpdata.data_disp)

--- a/direct_inelastic/ISIS/qtiGenie/ScanJaws.py
+++ b/direct_inelastic/ISIS/qtiGenie/ScanJaws.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import math
 ######################################################################
 # STEP 1: In instrument view choose Bragg peak,  then in the Draw menu select an area around it and "Apply and Save" 
@@ -10,7 +11,7 @@ import math
 jawstart=48    #jaw width for first run
 jawstep= -4    # jaw step for each run
 run_no=[32715,32716, 32717, 32718, 32719, 32720, 32721, 32722, 32723, 32724, 32725, 32727, 32728]#[range(32715,32726),32727,32728]
-jaw_opening = range(jawstart,jawstart+len(run_no)*jawstep,jawstep)
+jaw_opening = list(range(jawstart,jawstart+len(run_no)*jawstep,jawstep))
 folder='/archive/NDXMERLIN/Instrument/data/cycle_16_5/' # make folder string empty to use Mantid data search path
 instname='MER'
 dmin=2000  #you can convert to d-spacing (uncomment ConvertUnits line below) and go for a wide range 
@@ -22,7 +23,7 @@ intensity=[]
 for run,width in zip(run_no,jaw_opening):
 
     fname=instname+str(run)+'.raw'
-    print ' processing file ', fname, 
+    print(' processing file ', fname, end=' ') 
     
     jawWS = Load(Filename=folder+fname,LoadMonitors='Include')
     jawWS = NormaliseByCurrent(InputWorkspace=jawWS)
@@ -30,7 +31,7 @@ for run,width in zip(run_no,jaw_opening):
     jawWS = SumSpectra(InputWorkspace='jawWS', IncludeMonitors=False)
     #jawWS = ConvertUnits(InputWorkspace=jawWS,  Target='dSpacing')
     jawWS=Integration(InputWorkspace=jawWS,RangeLower=dmin,RangeUpper=dmax)
-    print ': Jaw width= ',width,'Integrated Counts=',jawWS.dataY(0)[0]
+    print(': Jaw width= ',width,'Integrated Counts=',jawWS.dataY(0)[0])
     intensity.append(jawWS.dataY(0)[0])
 
 plot(jaw_opening,intensity)

--- a/direct_inelastic/ISIS/qtiGenie/autoEi.py
+++ b/direct_inelastic/ISIS/qtiGenie/autoEi.py
@@ -1,5 +1,6 @@
 # takes wkspin as string of run number 
 # returns ei, as value and rebin parameners as string
+from __future__ import print_function
 import numpy as np
 from peakdet import *
 from mantid.simpleapi import *
@@ -52,7 +53,7 @@ def autoEi(WkspIn,BkgdGen=None,monspecin=None,BkgdLevel=None):
 	max1=maximal[:,1].argmax()
 	#get the correspoiding energy
 	ei=maximal[max1,0]
-	print ei
+	print(ei)
 	#generate some rebin parameters
 	#deltaE is set at 10 points per resolution function of 2%Ei this is to make sofqw3 work. 
 	#There is an issue with the overlapping polygon rebin that results in bad output if the energy transfer vector is 

--- a/direct_inelastic/ISIS/qtiGenie/autoreduce.py
+++ b/direct_inelastic/ISIS/qtiGenie/autoreduce.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import re
 sys.path.append("/opt/Mantid/bin")
@@ -27,7 +28,7 @@ InstrName = dataFilePath.lower().split('/ndx')[1].split('/')[0]
 #############################################
 
 
-print 'data file path: ' + dataFilePath
+print('data file path: ' + dataFilePath)
 sys.path.append(dataFilePath)
 
 iliad_setup(InstrName)
@@ -78,7 +79,7 @@ if loadFreshWB:
 ######################################################################
 
 
-print ' processing file ', dataFile
+print(' processing file ', dataFile)
 #w1 = dgreduce.getReducer().load_data(run,'w1')
 Load(Filename=dataFile,OutputWorkspace='w1',LoadMonitors='1');
 
@@ -91,9 +92,9 @@ if remove_background:
 # this section finds all the transmitted incident energies
 if len(ei) == 0:
    ei = find_chopper_peaks('w1_monitors');
-   print ei
+   print(ei)
     
-print 'energies to process are:'
+print('energies to process are:')
 print (ei)
 
 RenameWorkspace(InputWorkspace = 'w1',OutputWorkspace='w1_storage');
@@ -117,7 +118,7 @@ argi['monovan_mapfile']=monovan_mapfile;
 
 
 for ind,energy in enumerate(ei):
-    print "Reducing around energy: {0}".format(float(energy))
+    print("Reducing around energy: {0}".format(float(energy)))
     # Instrument Specific parameters used
     (energybin,tbin,t_elastic) = find_binning_range(energy,ebin);
                        

--- a/direct_inelastic/ISIS/qtiGenie/c2te_pyAlg.py
+++ b/direct_inelastic/ISIS/qtiGenie/c2te_pyAlg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.api import PythonAlgorithm, AlgorithmFactory
 from mantid.kernel import StringListValidator, StringMandatoryValidator
 from qtiGenie import *
@@ -19,9 +20,9 @@ class c2et(PythonAlgorithm):
 		dVan = self.getProperty("dVan")
 		Ei = float(self.getProperty("Ei"))
 		rebin = str(self.getProperty("Rebin"))
-		print rebin
+		print(rebin)
 		mapfile=self.getProperty("mapfile")
-		print mapfile
+		print(mapfile)
 		inst=self.getProperty("instrument")
 		kw=self.getProperty("keywords")
 		

--- a/direct_inelastic/ISIS/qtiGenie/ipyNotebookHelpers.py
+++ b/direct_inelastic/ISIS/qtiGenie/ipyNotebookHelpers.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 try:
   from mantidplot import *
 except ImportError:
@@ -68,7 +69,7 @@ class mplFig:
 		
 		else:
 			#input data is already a list of xyz or xye
-			print 'data is a list '
+			print('data is a list ')
 			self.data=data#x,y,e or ,x,y,zsignal
 		
 		self.init_params()

--- a/direct_inelastic/ISIS/qtiGenie/qtiGenie.py
+++ b/direct_inelastic/ISIS/qtiGenie/qtiGenie.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from xml.dom import minidom 
 from mantid.kernel import funcreturns
 from mantid.simpleapi import *
@@ -50,9 +51,9 @@ qtg_par["plotmkr"] = "";
 qtg_par["plotcolor"] = "red";
 mpl = 0
 if mpl==1:
-    print 'Using matplotlib graphics'
+    print('Using matplotlib graphics')
 if mpl==0:
-    print 'Using qtiplot graphics'
+    print('Using qtiplot graphics')
 
 
 save_dir = config.getString('defaultsave.directory')
@@ -74,7 +75,7 @@ iliad_reducer = dgreduce.getReducer
 
 #     iliad_set_calfile = dgreduce.set_cal_file
 os.chdir(save_dir)
-print 'Working directory set to: ',save_dir;
+print('Working directory set to: ',save_dir);
 
 #######################
 #######################
@@ -179,15 +180,15 @@ def fillqtiTable(data):
     
 #def arb_units(wb_run,sample_run,ei_guess,rebin,mapfile):
 def test(wb_run,sample_run,ei_guess,rebin,mapfile,**kwargs):
-    print wb_run,sample_run,ei_guess,rebin,mapfile,kwargs
+    print(wb_run,sample_run,ei_guess,rebin,mapfile,kwargs)
 
     for key in kwargs:
-        print "another keyword arg: %s: %s" % (key, kwargs[key])
+        print("another keyword arg: %s: %s" % (key, kwargs[key]))
     
     
-    if kwargs.has_key('fixei'):
+    if 'fixei' in kwargs:
         fix_ei = kwargs.get('fixei')
-        print fix_ei
+        print(fix_ei)
     
     
     
@@ -211,16 +212,16 @@ def listfiles():
     """
     aa= os.listdir(os.getcwd())
     for i in range(0,len(aa)):
-        print aa[i]
+        print(aa[i])
 def print_locals():
     a=locals()
     for i in range(0,len(a)):
-        print a[i]
+        print(a[i])
 
 def print_globals():
     a=locals()
     for i in range(0,len(a)):
-        print a[i]
+        print(a[i])
 
 
 ##instrument definitions
@@ -263,7 +264,7 @@ def setinst(iname=None):
             qtg_par[par_name]= values[0].attributes['val'].value
    
    
-    print "qtiGenie instrument set up to: ",qtg_par["instname"]
+    print("qtiGenie instrument set up to: ",qtg_par["instname"])
 
     
 def setmon_1_spec(spec):
@@ -272,26 +273,26 @@ def setmon_1_spec(spec):
     """
     global qtg_par
     qtg_par["mon1_spec"]=spec
-    print 'Monitor one spectrum changed to ',qtg_par["mon1_spec"]
+    print('Monitor one spectrum changed to ',qtg_par["mon1_spec"])
     return qtg_par["mon1_spec"]
 
 def showgpath():
     """
     shows the gloabal qtigenie variables
     """
-    print '----------------------------------------------------------'
-    print 'Global::: ', qtg_par["instname"], ': specific variables are:'
+    print('----------------------------------------------------------')
+    print('Global::: ', qtg_par["instname"], ': specific variables are:')
     
-    print 'Data directory::: ', os.getcwd(), ':'
+    print('Data directory::: ', os.getcwd(), ':')
     
-    print 'file extension::: ',qtg_par['data_file_ext'] , ':'
-    print 'dae path::: ', qtg_par["instdae"], ':'
+    print('file extension::: ',qtg_par['data_file_ext'] , ':')
+    print('dae path::: ', qtg_par["instdae"], ':')
     if qtg_par["norm-mon1-spec"] != "" :
-        print 'Monitor 1 spectrum' ,qtg_par["norm-mon1-spec"]
-        print 'Monitor 2 spectrum' ,qtg_par["ei-mon1-spec"]
-        print 'Monitor 3 spectrum' ,qtg_par["ei-mon2-spec"]
+        print('Monitor 1 spectrum' ,qtg_par["norm-mon1-spec"])
+        print('Monitor 2 spectrum' ,qtg_par["ei-mon1-spec"])
+        print('Monitor 3 spectrum' ,qtg_par["ei-mon2-spec"])
     else:
-        print 'No monitors are defined for this function'
+        print('No monitors are defined for this function')
     
     getgpath();
     
@@ -301,9 +302,9 @@ def getgpath(silent=False):
     """    
     current_path = config.getDataSearchDirs();
     if not(silent):
-        print 'inst_data:::'
+        print('inst_data:::')
         for i in range(0,len(current_path)):
-            print '         :::',current_path[i];
+            print('         :::',current_path[i]);
             
     return current_path;
 def addgpath(path):
@@ -319,7 +320,7 @@ def getspepath(silent=False):
     """    
     spepath=config.getString('defaultsave.directory')
     if not(silent):
-       print ' Default output data path:',spepath
+       print(' Default output data path:',spepath)
     
     return spepath;
      
@@ -359,10 +360,10 @@ def head(runnumber=0000000,keepWSwithResults=False):
     #enddate=parsWS.column('r_enddate') 
     #endtime=parsWS.column('r_endtime')
   
-    print 'RunID\t\t: '+instShort+header #+' to '+enddate+endtime
-    print 'Title\t\t: '+title     
+    print('RunID\t\t: '+instShort+header) #+' to '+enddate+endtime
+    print('Title\t\t: '+title)     
  
-    print 'Protons\t\t:', parsWS.column('r_gd_prtn_chrg')[0],' uAmps'
+    print('Protons\t\t:', parsWS.column('r_gd_prtn_chrg')[0],' uAmps')
 
     run_length = parsWS.column('r_dur')[0]
     if run_length > 3600 :
@@ -370,13 +371,13 @@ def head(runnumber=0000000,keepWSwithResults=False):
         run_length = run_length-hrs*3600
         mins= run_length/60
         sec = run_length - mins*60
-        print 'Run duration\t\t:', hrs,' hrs ',mins,' mins ',sec,' sec'
+        print('Run duration\t\t:', hrs,' hrs ',mins,' mins ',sec,' sec')
     elif run_length > 60:
         mins= run_length/60
         sec = run_length - mins*60
-        print 'Run duration\t\t:',mins,' mins ',sec,' sec' 
+        print('Run duration\t\t:',mins,' mins ',sec,' sec') 
     else:
-        print 'Run duration\t\t:',run_length,' sec'     
+        print('Run duration\t\t:',run_length,' sec')     
     
     #print 'More details available from Mantid RawFileInfo algorithm\n'
     if not(keepWSwithResults) :
@@ -411,7 +412,7 @@ def load(*args):
     wksp=r[0]
     if (args[0])=='dae': #runnumber == 'dae':
         dae_name = qtg_par["instdae"]
-        print 'Access DAE', dae_name
+        print('Access DAE', dae_name)
         awksp=LoadDAE(dae_name,OutputWorkspace=wksp)
         return mtd[wksp]
     else:
@@ -421,7 +422,7 @@ def load(*args):
         
         
         fullname=base_name+str(runnumber)
-        print fullname
+        print(fullname)
         awksp=Load(fullname,OutputWorkspace=wksp,Cache="Never")
         ConvertToDistribution(wksp)
         runinfo=RawFileInfo(fullname,GetRunParameters=True)
@@ -441,7 +442,7 @@ def load_spectra(runnumber,specmin,specmax):
 
     instname = qtg_par["instname"]   
     fullname=instname+str(runnumber)
-    print fullname
+    print(fullname)
     awksp=Load(fullname,OutputWorkspace=wksp,Cache="Never",SpectrumMin=specmin,SpectrumMax=specmax)
     ConvertToDistribution(wksp)
     runinfo=RawFileInfo(fullname,GetRunParameters=True)
@@ -469,7 +470,7 @@ def load_monitors(*args):
 
         instname = qtg_par["instname"]
         fullname=instname+str(runnumber)
-        print fullname
+        print(fullname)
 
         awksp=Load(fullname,OutputWorkspace=wksp,Cache="Never",LoadMonitors="Separate")
         try: 
@@ -486,7 +487,7 @@ def load_monitors(*args):
         return mtd[wksp+'_Monitors']
 
     else:
-        print 'error'
+        print('error')
 
 def getnumor(runnumber):
     """creates a string runnumber from interger input and pads with zerso to cope with isis 
@@ -534,7 +535,7 @@ def loadascii(name):
     n,r=funcreturns.lhs_info('both')
     wksp=r[0]
     fullname=os.getcwd()+'/'+name
-    print 'Loading ',fullname
+    print('Loading ',fullname)
     LoadAscii(fullname,OutputWorkspace=wksp,Separator="Tab",Unit="Empty")
     return mtd[wksp]
 
@@ -566,21 +567,21 @@ def whos():
     list all current loaded workspaces
     """
     names=mtd.getWorkspaceNames()
-    print 'Instrument name: ', qtg_par["instname"], '\t', 'Data Directory: ',os.getcwd()
-    print '---------------------------------------------------------------------------'
-    print 'WkSp Name', '\t', '\t', '\t', 'Allocated Mem', '\t', 'Title', '\t'
-    print '---------------------------------------------------------------------------'
+    print('Instrument name: ', qtg_par["instname"], '\t', 'Data Directory: ',os.getcwd())
+    print('---------------------------------------------------------------------------')
+    print('WkSp Name', '\t', '\t', '\t', 'Allocated Mem', '\t', 'Title', '\t')
+    print('---------------------------------------------------------------------------')
     for i in range(0,len(names)):
         name = names[i]
         tmp=mtd[name]
         mem=tmp.getMemorySize()/1024
         title=tmp.getTitle()
-        print name,'\t','\t','\t',mem,'Mb','\t',title
+        print(name,'\t','\t','\t',mem,'Mb','\t',title)
 def sync():
     names=mtd.getWorkspaceNames()
     for i in range(0,len(names)):
         name = names[i]
-        print name
+        print(name)
         #name = mtd[name]
         evalstr='global '+str(name)
         exec(evalstr)
@@ -590,7 +591,7 @@ def sync():
     
 def default_plotting(inp):
     global mpl	
-    print 'set default graphics to matplotlib (1) or qtiplot(0)'
+    print('set default graphics to matplotlib (1) or qtiplot(0)')
     mpl=inp
 
 def dspacing(wksp_in):
@@ -612,8 +613,8 @@ def get_ei(wksp_in,guess):
     mon3_spec = int(qtg_par["ei-mon2-spec"]);
     ei,mon2_peak,mon2_index=GetEi(wksp_in,mon2_spec,mon3_spec,guess)
     #ei = (wksp_in.getRun().getLogData("Ei").value)
-    print 'Incident Energy = ', ei, 'meV'
-    print 'Peak in monitor',mon2_index, 'at ', mon2_peak ,'usec'
+    print('Incident Energy = ', ei, 'meV')
+    print('Peak in monitor',mon2_index, 'at ', mon2_peak ,'usec')
     return ei,mon2_peak
 def diag(wb_wksp,run_wksp):
     """
@@ -632,7 +633,7 @@ def diag(wb_wksp,run_wksp):
     
     
     bad_dets=maskUnion(Run_SpectraList,WB_SpectraList)
-    print 'number of masked spectra = ', len(bad_dets)
+    print('number of masked spectra = ', len(bad_dets))
     return bad_dets
 
 def maskUnion(a,b):
@@ -671,14 +672,14 @@ def normalise(*args):
         wksp_in =  args[0]
         method  =  args[1]
         if method == 1:
-            print 'Normalise to monitor 1'
+            print('Normalise to monitor 1')
             #use defaults for the rest
             mon_spec=qtg_par["mon1_spec"]
             time_min=1000
             time_max=2000
                 
             if wksp_in.isDistribution():
-                print 'input wksp is distribution'				
+                print('input wksp is distribution')				
                 ConvertFromDistribution(wksp_in)
                 NormaliseToMonitor(InputWorkspace=wksp_in,OutputWorkspace=wksp_out,MonitorSpectrum=mon_spec,IntegrationRangeMin=time_min,IntegrationRangeMax=time_max,IncludePartialBins="1")
                 #put all data back to distriubution				
@@ -688,7 +689,7 @@ def normalise(*args):
                 NormaliseToMonitor(InputWorkspace=wksp_in,OutputWorkspace=wksp_out,MonitorSpectrum=mon_spec,IntegrationRangeMin=time_min,IntegrationRangeMax=time_max,IncludePartialBins="1")
 
         if method ==2:
-            print 'Normalise to current'
+            print('Normalise to current')
             NormaliseByCurrent(wksp_in, OutputWorkspace=wksp_out)
         
 
@@ -698,13 +699,13 @@ def normalise(*args):
         #assume normalise to monitor
         if method == 1:
             mon1_spec = qtg_par["mon1_spec"]
-            print 'Normalise to monitor ', args[1],'is spec ',mon1_spec,'between ',args[2],' and ',args[3],' usec'
+            print('Normalise to monitor ', args[1],'is spec ',mon1_spec,'between ',args[2],' and ',args[3],' usec')
             #use inputs for the rest
             mon_spec=mon1_spec
             time_min=str(args[2])
             time_max=str(args[3])
             if wksp_in.isDistribution():
-                print 'input wksp is distribution'				
+                print('input wksp is distribution')				
                 ConvertFromDistribution(wksp_in)
                 NormaliseToMonitor(InputWorkspace=wksp_in,OutputWorkspace=wksp_out,MonitorSpectrum=mon_spec,IntegrationRangeMin=time_min,IntegrationRangeMax=time_max,IncludePartialBins="1")
                 #put all data back to distriubution				
@@ -729,20 +730,20 @@ def integrate_over_runs(runstart,runstop,tmin,tmax,specmin,specmax,*args,**kwarg
     integrate_over_runs(runstart,runstop,tmin,tmax,specmin,specmax,xaxis_start_pos,xstep,normalise=mon,mon_range=[1000,2000])
     integrate_over_runs(runstart,runstop,tmin,tmax,specmin,specmax,xaxis_start_pos,xstep,normalise=uamp)
     """
-    if kwargs.has_key('normalise'):
+    if 'normalise' in kwargs:
         norm_method = kwargs.get('normalise')
         if norm_method=='uamp':
-            print 'Normalise to uamps'
+            print('Normalise to uamps')
             norm=2
         elif norm_method=='mon':
-            print 'Normalise to monitor 1'
+            print('Normalise to monitor 1')
             norm=1
     
     else:
-        print 'default uamphr normalisation use keyword normalise to change'
+        print('default uamphr normalisation use keyword normalise to change')
         norm =2
 
-    if kwargs.has_key('normalise') and kwargs.get('normalise')=='mon' and kwargs.has_key('mon_range'):
+    if 'normalise' in kwargs and kwargs.get('normalise')=='mon' and 'mon_range' in kwargs:
         mon_int_range=kwargs.get('mon_range')
 
     jj=1
@@ -756,7 +757,7 @@ def integrate_over_runs(runstart,runstop,tmin,tmax,specmin,specmax,*args,**kwarg
         temp = mtd.getTableWorkspace('Raw_RPB')
         uamps=temp.getDouble('r_gd_prtn_chrg', 0)
         if uamps==0:
-            print 'Integral from run ', i, 'is NaN because zero beam current'
+            print('Integral from run ', i, 'is NaN because zero beam current')
             outdat.setCell(1,jj,jj)
             outdat.setCell(2,jj,0)
             outdat.setCell(3,jj,0)
@@ -764,7 +765,7 @@ def integrate_over_runs(runstart,runstop,tmin,tmax,specmin,specmax,*args,**kwarg
             #tmp=load(i)
             #RAE added:
             tmp=load_spectra(i,specmin,specmax)
-            if kwargs.has_key('normalise') and kwargs.get('normalise')=='mon' and kwargs.has_key('mon_range'):		
+            if 'normalise' in kwargs and kwargs.get('normalise')=='mon' and 'mon_range' in kwargs:		
                 out=normalise(tmp,norm,mon_int_range[0],mon_int_range[1])
             else:
                 out=normalise(tmp,norm)
@@ -777,7 +778,7 @@ def integrate_over_runs(runstart,runstop,tmin,tmax,specmin,specmax,*args,**kwarg
                 outdat.setCell(1,jj,jj)
             outdat.setCell(2,jj,tmp.readY(0)[0])
             outdat.setCell(3,jj,tmp.readE(0)[0])
-            print 'Integral from run ', i, '=' ,tmp.readY(0)[0],'+/-',tmp.readE(0)[0]
+            print('Integral from run ', i, '=' ,tmp.readY(0)[0],'+/-',tmp.readE(0)[0])
         jj=jj+1
     mantidplot.plot(outdat,(1,2,3),2)
     return outdat
@@ -808,7 +809,7 @@ def integrate_maps_monitors_over_runs(runstart,runstop,tmin,tmax,mypath):
         temp = mtd.getTableWorkspace('Raw_RPB')
         uamps=temp.getDouble('r_gd_prtn_chrg', 0)
         if uamps==0:
-            print 'Integral from run ', i, 'is NaN because zero beam current'
+            print('Integral from run ', i, 'is NaN because zero beam current')
             outdat.setCell(1,jj,jj)
             outdat.setCell(2,jj,0)
             outdat.setCell(3,jj,0)
@@ -851,7 +852,7 @@ def integrate_maps_monitors_over_runs(runstart,runstop,tmin,tmax,mypath):
                         print('Unexpected item in the bagging area')
                         badflag=True
             if badflag:
-                print 'Integral from run ', i, 'is NaN because problem getting mon spectra'
+                print('Integral from run ', i, 'is NaN because problem getting mon spectra')
                 outdat.setCell(1,jj,jj)
                 outdat.setCell(2,jj,0)
                 outdat.setCell(3,jj,0)
@@ -869,7 +870,7 @@ def integrate_maps_monitors_over_runs(runstart,runstop,tmin,tmax,mypath):
                 outdat.setCell(1,jj,jj)
                 outdat.setCell(2,jj,tmp.readY(0)[0])
                 outdat.setCell(3,jj,tmp.readE(0)[0])
-                print 'Integral from run ', i, '=' ,tmp.readY(0)[0],'+/-',tmp.readE(0)[0]
+                print('Integral from run ', i, '=' ,tmp.readY(0)[0],'+/-',tmp.readE(0)[0])
         jj=jj+1
     mantidplot.plot(outdat,(1,2,3),2)
     return outdat
@@ -903,7 +904,7 @@ def etrans(*args):
     if len(args)==1:
         wksp_in=args[0]
         ei = float(wksp_in.getRun().getLogData("Ei").value())
-        print 'Converting to energy transfer ei = ', ei,'meV'
+        print('Converting to energy transfer ei = ', ei,'meV')
         
         ConvertUnits(InputWorkspace=wksp_in,OutputWorkspace=wksp_out,Target="DeltaE",EMode="Direct",EFixed=ei)
     
@@ -911,7 +912,7 @@ def etrans(*args):
         wksp_in=args[0]
         ei=args[1]
         
-        print 'Converting to energy transfer ei = ', ei, 'meV'
+        print('Converting to energy transfer ei = ', ei, 'meV')
         
         ConvertUnits(InputWorkspace=wksp_in,OutputWorkspace=wksp_out,Target="DeltaE",EMode="Direct",EFixed=ei)
 
@@ -968,7 +969,7 @@ def avrg_spectra(ws_name,index_min=0,index_max=sys.float_info.max,calc_sigma_avr
     nZeroSpectra   = pOutWS.getRun().getLogData("NumZeroSpectra").value
     if (calc_sigma_avrg):
         if nZeroSpectra>0:
-           print "->avrg_spectra:: ",nZeroSpectra," spectra out of: ",nUsedSpectra," have have been droped out due to no counts in it"          
+           print("->avrg_spectra:: ",nZeroSpectra," spectra out of: ",nUsedSpectra," have have been droped out due to no counts in it")          
 
         nUsedSpectra-= nZeroSpectra
         if(nUsedSpectra <=0) :
@@ -1041,7 +1042,7 @@ def integrate(*args):
         specrange_hi=args[4]-1
         Integration(InputWorkspace=wksp_in,OutputWorkspace=wksp_out,RangeLower=xrange_lo,RangeUpper=xrange_hi,StartWorkspaceIndex=specrange_lo,EndWorkspaceIndex=specrange_hi,IncludePartialBins="1")
     if wksp_out =='tmp_integral':
-        print 'Integral = ' ,mtd[wksp_out].readY(0)[0],'+/-',mtd[wksp_out].readE(0)[0]
+        print('Integral = ' ,mtd[wksp_out].readY(0)[0],'+/-',mtd[wksp_out].readE(0)[0])
         
     return mtd[wksp_out]
 def transpose(wksp_in):
@@ -1153,7 +1154,7 @@ def wccr_ang_maps(runnumber):
 
     tt=title[pos+5:ss]
     ang_str=tt.rstrip()
-    print "wccr angle is "+ang_str+" degrees"
+    print("wccr angle is "+ang_str+" degrees")
     ang_out=float(ang_str)
     return ang_out
 
@@ -1251,7 +1252,7 @@ def get_maps_spec(win,ang):
         specout=spec_lo+1
     #note final statement is to catch the case where angle specified is exactly between two detectors
     angout=w2_.readX(0)[specout-1]
-    print "Closest spectrum is no."+str(specout)+" with a scattering angle of "+str(angout)+" degrees"
+    print("Closest spectrum is no."+str(specout)+" with a scattering angle of "+str(angout)+" degrees")
     DeleteWorkspace("w2_")	
     return specout
 
@@ -1279,7 +1280,7 @@ def dscan_maps_analysis(run_start,run_end,d_lo,d_hi,specno):
         outdat.setCell(1,jj,wccr)
         outdat.setCell(2,jj,tmp.readY(0)[0])
         outdat.setCell(3,jj,tmp.readE(0)[0])
-        print 'Integral from run ', i, '=' ,tmp.readY(0)[0],'+/-',tmp.readE(0)[0]
+        print('Integral from run ', i, '=' ,tmp.readY(0)[0],'+/-',tmp.readE(0)[0])
         jj=jj+1
     mantidplot.plot(outdat,(1,2,3),2)
     DeleteWorkspace("wtmp1_")
@@ -1321,7 +1322,7 @@ def export_masks(ws,fileName='',returnMasks=False):
             # got real spectra ID, which would correspond real spectra num to spectra ID map
             ms = sp.getSpectrumNo();
         except Exception: 
-            print " Can not get spectra No: ",i
+            print(" Can not get spectra No: ",i)
             masks.append(ms) 
             continue        
         
@@ -1337,9 +1338,9 @@ def export_masks(ws,fileName='',returnMasks=False):
 
     nMasks = len(masks);
     if nMasks == 0:
-        print 'workspace ',ws_name,' have no masked spectra'
+        print('workspace ',ws_name,' have no masked spectra')
         return masks
-    print 'workspace ',ws_name,' have ',nMasks,' masked spectra'
+    print('workspace ',ws_name,' have ',nMasks,' masked spectra')
     
     filename=''
     if len(fileName)==0 :
@@ -1576,7 +1577,7 @@ def convertDetDataToNexus(detDotDatFileName):
         file.putdata(detTubeIndex)
         file.closedata()   
     except IOError as e:
-        print "IOError writing to file ",outFileName
+        print("IOError writing to file ",outFileName)
     # close detectors group
     file.closegroup()    
     file.close() 
@@ -1584,72 +1585,72 @@ def convertDetDataToNexus(detDotDatFileName):
 
 def help(*args):
     if len(args)==0:
-        print '!-------------------------------------------------------------------!'    
-        print '!                  Mantid Built in Fucntions                        !'
-        print '!-------------------------------------------------------------------!'            
+        print('!-------------------------------------------------------------------!')    
+        print('!                  Mantid Built in Fucntions                        !')
+        print('!-------------------------------------------------------------------!')            
         mantidHelp()
-        print '!-------------------------------------------------------------------!'    
-        print '!-------------------------------------------------------------------!'    
-        print '!                  qtiGenie functions                               !'
-        print '!-------------------------------------------------------------------!'    
-        print '\t''trim(dat,t1,t2) '
-        print '\t''listfiles() '
-        print '\t''setinst() '
-        print '\t''head(runnumber) '
-        print '\t''iv(wksp_in) '
-        print '\t''load(*args) '
-        print '\t''load_monitors(*args) '
-        print '\t''getnumor(runnumber) '
-        print '\t''loadascii(name) '
-        print '\t''ass(wksp) '	
-        print '\t''clear(wksp) '	
-        print '\t''whos() '
-        print '\t''default_plotting(inp) '
-        print '\t''dspacing(wksp_in) '
-        print '\t''get_ei(wksp_in,guess) '
-        print '\t''normalise(*args) '
-        print '\t''rebin(wksp_in,params) '
-        print '\t''integrate_over_runs(runstart,runstop,tmin,tmax,specmin,specmax) '	
-        print '\t''Log(wksp_in) '	
-        print '\t''Ln(wksp_in) '
-        print '\t''etrans(*args) '
-        print '\t''sumspec(*args) '
-        print '\t''integrate(*args) '
-        print '\t''transpose(wksp_in) '
-        print '\t''pwksp(wksp,spec) '
-        print '\t''changecolour(*args) '
-        print '\t''changemarker(*args) '
-        print '\t''p(spec) '
-        print '\t''pe(spec) '
-        print '\t''getspec(spec) '
-        print '\t''get2d() '
-        print '\t''p2d(*args) '
-        print '\t''psurf(*args) '
-        print '\t''plus(a,b) '
-        print '\t''minus(a,b) '
-        print '\t''mult(a,b) '
-        print '\t''div(a,b) '         
-        print '\t''help() '
-        print '--------------------------------------------------------------------'	
-        print 'qtiGenie classes'
-        print '--------------------------------------------------------------------'
-        print 'class Data_1D() '
-        print '--------------------------------------------------------------------'
-        print '\t''__init__(Data_1D) '  
-        print '\t''plot(wksp) '
-        print '\t''plotwe(wksp) '
-        print '\t''Add_1d(wksp,factor) '
-        print '\t''Minus_1D(wksp,factor) '
-        print '\t''Multiply_1d(wksp,factor) '
-        print '\t''Divide_1d(wksp,factor) '
-        print '\t''integrate(wksp,t1,t2) '
-        print '\t''xscale(dat,t1,t2) '
-        print '--------------------------------------------------------------------'	
-        print 'class Data_2D()'
-        print '--------------------------------------------------------------------'
-        print '\t''__init__(Data_2D) '
-        print '\t''sumspec(wksp,*args) '
-        print '\t''sum2d(wsk,s1,s2) '
+        print('!-------------------------------------------------------------------!')    
+        print('!-------------------------------------------------------------------!')    
+        print('!                  qtiGenie functions                               !')
+        print('!-------------------------------------------------------------------!')    
+        print('\t''trim(dat,t1,t2) ')
+        print('\t''listfiles() ')
+        print('\t''setinst() ')
+        print('\t''head(runnumber) ')
+        print('\t''iv(wksp_in) ')
+        print('\t''load(*args) ')
+        print('\t''load_monitors(*args) ')
+        print('\t''getnumor(runnumber) ')
+        print('\t''loadascii(name) ')
+        print('\t''ass(wksp) ')	
+        print('\t''clear(wksp) ')	
+        print('\t''whos() ')
+        print('\t''default_plotting(inp) ')
+        print('\t''dspacing(wksp_in) ')
+        print('\t''get_ei(wksp_in,guess) ')
+        print('\t''normalise(*args) ')
+        print('\t''rebin(wksp_in,params) ')
+        print('\t''integrate_over_runs(runstart,runstop,tmin,tmax,specmin,specmax) ')	
+        print('\t''Log(wksp_in) ')	
+        print('\t''Ln(wksp_in) ')
+        print('\t''etrans(*args) ')
+        print('\t''sumspec(*args) ')
+        print('\t''integrate(*args) ')
+        print('\t''transpose(wksp_in) ')
+        print('\t''pwksp(wksp,spec) ')
+        print('\t''changecolour(*args) ')
+        print('\t''changemarker(*args) ')
+        print('\t''p(spec) ')
+        print('\t''pe(spec) ')
+        print('\t''getspec(spec) ')
+        print('\t''get2d() ')
+        print('\t''p2d(*args) ')
+        print('\t''psurf(*args) ')
+        print('\t''plus(a,b) ')
+        print('\t''minus(a,b) ')
+        print('\t''mult(a,b) ')
+        print('\t''div(a,b) ')         
+        print('\t''help() ')
+        print('--------------------------------------------------------------------')	
+        print('qtiGenie classes')
+        print('--------------------------------------------------------------------')
+        print('class Data_1D() ')
+        print('--------------------------------------------------------------------')
+        print('\t''__init__(Data_1D) ')  
+        print('\t''plot(wksp) ')
+        print('\t''plotwe(wksp) ')
+        print('\t''Add_1d(wksp,factor) ')
+        print('\t''Minus_1D(wksp,factor) ')
+        print('\t''Multiply_1d(wksp,factor) ')
+        print('\t''Divide_1d(wksp,factor) ')
+        print('\t''integrate(wksp,t1,t2) ')
+        print('\t''xscale(dat,t1,t2) ')
+        print('--------------------------------------------------------------------')	
+        print('class Data_2D()')
+        print('--------------------------------------------------------------------')
+        print('\t''__init__(Data_2D) ')
+        print('\t''sumspec(wksp,*args) ')
+        print('\t''sum2d(wsk,s1,s2) ')
     else:        
         execstr='print '+str(args[0])+'.__doc__'
         exec(execstr)
@@ -1657,8 +1658,8 @@ def help(*args):
         
 # set default instrument from Mantid configuration
 setinst();
-print 'You can change it by issuing setinst(InstrumentName) command'
-print 'where InstrumentName can be MER, MAR, MAP, LET, TSK or XSD'
+print('You can change it by issuing setinst(InstrumentName) command')
+print('where InstrumentName can be MER, MAR, MAP, LET, TSK or XSD')
         
 
 if __name__=="__main__":

--- a/direct_inelastic/ISIS/qtiGenie/utils.py
+++ b/direct_inelastic/ISIS/qtiGenie/utils.py
@@ -6,16 +6,17 @@
 |=============================================================================|=======|	
 1                                                                            80   <tab>
 '''
+from __future__ import print_function
 import sys, os
 import dis, inspect, opcode
 def ls():
-	print os.getcwd()	
+	print(os.getcwd())	
 	files=os.listdir(os.getcwd())
 	for i in range(0,len(files)):
 
-                print files[i]
+                print(files[i])
 def pwd():
-	print os.getcwd()
+	print(os.getcwd())
 def cd(dir_str):
 	os.chdir(dir_str)
 def lineno():
@@ -112,12 +113,12 @@ def decompile(code_object):
  
 # Print the byte code in a human readable format
 def pretty_print(instructions):
-	print '%5s %-20s %3s  %5s  %-20s  %s' %  ('OFFSET', 'INSTRUCTION', 'OPCODE', 'ARG', 'TYPE', 'VALUE')
+	print('%5s %-20s %3s  %5s  %-20s  %s' %  ('OFFSET', 'INSTRUCTION', 'OPCODE', 'ARG', 'TYPE', 'VALUE'))
 	for (offset, op, name, argument, argtype, argvalue) in instructions:
-		print '%5d  %-20s (%3d)  ' % (offset, name, op),
+		print('%5d  %-20s (%3d)  ' % (offset, name, op), end=' ')
 		if argument != None:
-			print '%5d  %-20s  (%s)' % (argument, argtype, argvalue),
-		print
+			print('%5d  %-20s  (%s)' % (argument, argtype, argvalue), end=' ')
+		print()
 
 def expecting():
 	#{{{

--- a/direct_inelastic/LET/LETReduction_2018_2Performance.py
+++ b/direct_inelastic/LET/LETReduction_2018_2Performance.py
@@ -28,7 +28,7 @@ class LETReduction(ReductionWrapper_withPerformance):
        # the range of files to reduce. This range ignored when deployed from autoreduction,
        # unless you going to sum these files. 
        # The range of numbers or run number is used when you run reduction from PC.
-       prop['sample_run'] = range(53518,53609) # 'LET18547.n001'
+       prop['sample_run'] = list(range(53518,53609)) # 'LET18547.n001'
        prop['wb_run'] = 51744  # monovan run number 
        #
        prop['sum_runs'] = False # set to true to sum everything provided to sample_run

--- a/direct_inelastic/LET/LETReduction_2018_sample.py
+++ b/direct_inelastic/LET/LETReduction_2018_sample.py
@@ -30,7 +30,7 @@ class LETReduction(ReductionWrapper):
        # unless you going to sum these files. 
        # The range of numbers or run number is used when you run reduction from PC.
       # prop['sample_run'] = range(50359,52000) # 'LET18547.n001'
-       prop['sample_run']=range(50776,50793) #SET DATA RUN NUMBERS GIRI
+       prop['sample_run']=list(range(50776,50793)) #SET DATA RUN NUMBERS GIRI
        prop['wb_run'] = 45879   # monovan run number 
        #
        prop['sum_runs'] = True # set to true to sum everything provided to sample_run

--- a/direct_inelastic/LET/LETReduction_2019_1.py
+++ b/direct_inelastic/LET/LETReduction_2019_1.py
@@ -30,7 +30,7 @@ class LETReduction(ReductionWrapper):
        # unless you going to sum these files. 
        # The range of numbers or run number is used when you run reduction from PC.
       # prop['sample_run'] = range(50359,52000) # 'LET18547.n001'
-       prop['sample_run']=range(50776,50793) #SET DATA RUN NUMBERS GIRI
+       prop['sample_run']=list(range(50776,50793)) #SET DATA RUN NUMBERS GIRI
        prop['wb_run'] = 45879   # monovan run number 
        #
        prop['sum_runs'] = True # set to true to sum everything provided to sample_run

--- a/direct_inelastic/LET/LETReduction_FilterPulses.py
+++ b/direct_inelastic/LET/LETReduction_FilterPulses.py
@@ -1,4 +1,5 @@
 """ Sample LET reduction script """ 
+from __future__ import print_function
 import os,sys
 #os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
 from mantid import *
@@ -29,7 +30,7 @@ class LETReduction(ReductionWrapper):
        # the range of files to reduce. This range ignored when deployed from autoreduction,
        # unless you going to sum these files. 
        # The range of numbers or run number is used when you run reduction from PC.
-       prop['sample_run'] = range(26772, 26811) # 'LET18547.n001'
+       prop['sample_run'] = list(range(26772, 26811)) # 'LET18547.n001'
        prop['wb_run'] = 25653   # monovan run number 
        #
        prop['sum_runs'] = False # set to true to sum everything provided to sample_run
@@ -87,7 +88,7 @@ class LETReduction(ReductionWrapper):
           Overload only if custom reduction is needed or 
           special features are requested
       """
-      print 'Input file: ',input_file
+      print('Input file: ',input_file)
       if input_file:
           self.reducer.prop_man.sample_run = input_file
       ws = PropertyManager.sample_run.get_workspace()
@@ -150,19 +151,19 @@ def filter_ts1_pulses(ws,peak_period=20000,peak_res = 30):
     xmin = 0 #x_s[0]
     xmax = x_s[-1]
     #ws=Rebin(ws,OutputWorkspace=ws.name(),Params=[xmin,xmax,10],PreserveEvents=1)
-    bin_ranges = range(int(xmin),int(xmax),peak_period)
+    bin_ranges = list(range(int(xmin),int(xmax),peak_period))
     nb = len(bin_ranges)-1
 
     ws_list = []
     r_min = xmin
-    print "Splitting input workspace {0} into {1} time intervals excluding specified periods".format(ws.name(),nb)
+    print("Splitting input workspace {0} into {1} time intervals excluding specified periods".format(ws.name(),nb))
     for ind,x_min in enumerate(bin_ranges):
         r_max = x_min + peak_period-1
         if r_max > xmax:
             r_max = xmax
         if r_max<=r_min:
             continue
-        print 'Step #{0}/{1}; r_min={2}, r_max={3}'.format(ind+1,nb,r_min,r_max)
+        print('Step #{0}/{1}; r_min={2}, r_max={3}'.format(ind+1,nb,r_min,r_max))
         part  = FilterByXValue(ws,OutputWorkspace ='{0}_{1}'.format(ws.name(),ind+1),XMin=r_min,XMax=r_max)
         ws_list.append(part)
 		

--- a/direct_inelastic/LET/LETReduction_Sample.py
+++ b/direct_inelastic/LET/LETReduction_Sample.py
@@ -29,7 +29,7 @@ class LETReduction(ReductionWrapper):
        # the range of files to reduce. This range ignored when deployed from autoreduction,
        # unless you going to sum these files. 
        # The range of numbers or run number is used when you run reduction from PC.
-       prop['sample_run'] = range(18547,18633) # 'LET18547.n001'
+       prop['sample_run'] = list(range(18547,18633)) # 'LET18547.n001'
        prop['wb_run'] = 18484   # monovan run number 
        #
        prop['sum_runs'] = False # set to true to sum everything provided to sample_run

--- a/direct_inelastic/LET/PolCorr.py
+++ b/direct_inelastic/LET/PolCorr.py
@@ -69,7 +69,7 @@ class Reduce():
                     NSF_run = run + 1
                     SF_run = run
 
-                print(("Loading quartz runs {0} (NSF) and {1} (SF) at {2:<3.2f}meV".format(NSF_run,SF_run, ei)))
+                print("Loading quartz runs {0} (NSF) and {1} (SF) at {2:<3.2f}meV".format(NSF_run,SF_run, ei))
                 NSF_quartz = LoadNXSPE(self.name_format.format(NSF_run, ei))
                 SF_quartz  = LoadNXSPE(self.name_format.format(SF_run, ei))
                 
@@ -115,8 +115,8 @@ class Reduce():
             fit_check = CreateWorkspace(np.linspace(1,256,num=256),np.array(fit))
 
             print("****************************************") 
-            print(("PF   = {0:1.3f} +/- {1:1.3f}".format(PF, PFe)))
-            print(("P_He = {0:1.3f} +/- {1:1.3f}".format(PHe, PHee)))
+            print("PF   = {0:1.3f} +/- {1:1.3f}".format(PF, PFe))
+            print("P_He = {0:1.3f} +/- {1:1.3f}".format(PHe, PHee))
             print("****************************************") 
 
 #-------------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ class Reduce():
         times = []
         
         print("\nStarting get_helium_from_ROI...")
-        print(("Using {0} meV rep with PF={1}".format(ei,PF)))
+        print("Using {0} meV rep with PF={1}".format(ei,PF))
         print("****************************************************")        
         for run in self.sample_runs[::2]:
             if self.NSF_first:
@@ -151,7 +151,7 @@ class Reduce():
                 NSF_run = run + 1
                 SF_run = run
 
-            print(("Calculating P_He from ROI for runs NSF:{0} and SF:{1} at {2:<3.2f}meV ".format(NSF_run,SF_run,ei)))
+            print("Calculating P_He from ROI for runs NSF:{0} and SF:{1} at {2:<3.2f}meV ".format(NSF_run,SF_run,ei))
 
 # load data and extract dummy monitor spectra from ROI
             NSF_roi = Load("LET000{0}.nxs".format(NSF_run))
@@ -209,7 +209,7 @@ class Reduce():
         he_fit      = exp_decay(times, self.T1, self.PHe0)
         he_fit_ws   = CreateWorkspace(np.array(times),np.array(he_fit))
 
-        print(("\nInitial Cell polarization P0={0:1.3f}+/-{1:1.3f} with lifetime T1={2:3.2f}+/-{3:1.2f}".format(self.PHe0,self.PHe0e,-self.T1,self.T1e)))
+        print("\nInitial Cell polarization P0={0:1.3f}+/-{1:1.3f} with lifetime T1={2:3.2f}+/-{3:1.2f}".format(self.PHe0,self.PHe0e,-self.T1,self.T1e))
         print("************************************************************************") 
 
 #-------------------------------------------------------------------------------------
@@ -232,7 +232,7 @@ class Reduce():
         times = []
 
         print("\nStarting get_helium_parameters...")
-        print(("Using {0} meV rep with PF={1}".format(ei,PF)))
+        print("Using {0} meV rep with PF={1}".format(ei,PF))
         print("****************************************************")        
         for run in self.sample_runs[::2]:
             if self.NSF_first:
@@ -242,7 +242,7 @@ class Reduce():
                 NSF_run = run + 1
                 SF_run = run
 
-            print(("Calculating P_He for runs NSF:{0} and SF:{1} at {2:<3.2f}meV with TOF {3:>6.0f} us".format(NSF_run,SF_run,ei,TOF)))
+            print("Calculating P_He for runs NSF:{0} and SF:{1} at {2:<3.2f}meV with TOF {3:>6.0f} us".format(NSF_run,SF_run,ei,TOF))
 
 #load monitors and calculate flipping ratios
             NSF_monitors = LoadNexusMonitors("LET000{0}.nxs".format(NSF_run))
@@ -293,7 +293,7 @@ class Reduce():
         he_fit      = exp_decay(times, self.T1, self.PHe0)
         he_fit_ws   = CreateWorkspace(np.array(times),np.array(he_fit))
 
-        print(("\nInitial Cell polarization P0={0:1.3f}+/-{1:1.3f} with lifetime T1={2:3.2f}+/-{3:1.2f}".format(self.PHe0,self.PHe0e,-self.T1,self.T1e)))
+        print("\nInitial Cell polarization P0={0:1.3f}+/-{1:1.3f} with lifetime T1={2:3.2f}+/-{3:1.2f}".format(self.PHe0,self.PHe0e,-self.T1,self.T1e))
         print("************************************************************************") 
         
 #--------------------------------------------------------------------------
@@ -308,7 +308,7 @@ class Reduce():
 
             PF = next(PF_iter)
             print("****************************************")
-            print(("\ncorrect_data: Correcting {0:<3.2f}meV rep with PF={1} \n".format(ei,PF)))
+            print("\ncorrect_data: Correcting {0:<3.2f}meV rep with PF={1} \n".format(ei,PF))
             NSF_out = "PLET_{0}_{1:<3.2f}meV_NSF".format(self.label,ei)
             SF_out  = "PLET_{0}_{1:<3.2f}meV_SF".format(self.label,ei)   
 
@@ -340,7 +340,7 @@ class Reduce():
                     NSF_run = run + 1
                     SF_run = run
 
-                print(("Correcting runs NSF:{0} and SF:{1} at {2:<3.2f}meV".format(NSF_run,SF_run,ei)))
+                print("Correcting runs NSF:{0} and SF:{1} at {2:<3.2f}meV".format(NSF_run,SF_run,ei))
                 NSF_One2One = LoadNXSPE(self.name_format.format(NSF_run, ei))
                 SF_One2One  = LoadNXSPE(self.name_format.format(SF_run, ei))   
 
@@ -350,7 +350,7 @@ class Reduce():
                 PHe = self.PHe0 * np.exp(time / self.T1)
 
                 FAP = PF * np.tanh(opacity*(1.0/np.cos(gammaspace)*PHe))
-                print(("After {0:1.2f} hours, cell polarization is {1:1.3f}".format(time,PHe)))
+                print("After {0:1.2f} hours, cell polarization is {1:1.3f}".format(time,PHe))
                 flipping_ratio = (1.0 + FAP) / (1.0 - FAP)
                 transmission = np.exp(-opacity) * np.cosh(opacity * PHe)
                 Scharpf = (1.0 / (flipping_ratio - 1.0))

--- a/direct_inelastic/LET/PolCorr.py
+++ b/direct_inelastic/LET/PolCorr.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid import *
 from mantid.simpleapi import *
 from scipy.optimize import curve_fit
@@ -68,7 +69,7 @@ class Reduce():
                     NSF_run = run + 1
                     SF_run = run
 
-                print("Loading quartz runs {0} (NSF) and {1} (SF) at {2:<3.2f}meV".format(NSF_run,SF_run, ei))
+                print(("Loading quartz runs {0} (NSF) and {1} (SF) at {2:<3.2f}meV".format(NSF_run,SF_run, ei)))
                 NSF_quartz = LoadNXSPE(self.name_format.format(NSF_run, ei))
                 SF_quartz  = LoadNXSPE(self.name_format.format(SF_run, ei))
                 
@@ -114,8 +115,8 @@ class Reduce():
             fit_check = CreateWorkspace(np.linspace(1,256,num=256),np.array(fit))
 
             print("****************************************") 
-            print("PF   = {0:1.3f} +/- {1:1.3f}".format(PF, PFe))
-            print("P_He = {0:1.3f} +/- {1:1.3f}".format(PHe, PHee))
+            print(("PF   = {0:1.3f} +/- {1:1.3f}".format(PF, PFe)))
+            print(("P_He = {0:1.3f} +/- {1:1.3f}".format(PHe, PHee)))
             print("****************************************") 
 
 #-------------------------------------------------------------------------------------
@@ -140,7 +141,7 @@ class Reduce():
         times = []
         
         print("\nStarting get_helium_from_ROI...")
-        print("Using {0} meV rep with PF={1}".format(ei,PF))
+        print(("Using {0} meV rep with PF={1}".format(ei,PF)))
         print("****************************************************")        
         for run in self.sample_runs[::2]:
             if self.NSF_first:
@@ -150,7 +151,7 @@ class Reduce():
                 NSF_run = run + 1
                 SF_run = run
 
-            print("Calculating P_He from ROI for runs NSF:{0} and SF:{1} at {2:<3.2f}meV ".format(NSF_run,SF_run,ei))
+            print(("Calculating P_He from ROI for runs NSF:{0} and SF:{1} at {2:<3.2f}meV ".format(NSF_run,SF_run,ei)))
 
 # load data and extract dummy monitor spectra from ROI
             NSF_roi = Load("LET000{0}.nxs".format(NSF_run))
@@ -208,7 +209,7 @@ class Reduce():
         he_fit      = exp_decay(times, self.T1, self.PHe0)
         he_fit_ws   = CreateWorkspace(np.array(times),np.array(he_fit))
 
-        print("\nInitial Cell polarization P0={0:1.3f}+/-{1:1.3f} with lifetime T1={2:3.2f}+/-{3:1.2f}".format(self.PHe0,self.PHe0e,-self.T1,self.T1e))
+        print(("\nInitial Cell polarization P0={0:1.3f}+/-{1:1.3f} with lifetime T1={2:3.2f}+/-{3:1.2f}".format(self.PHe0,self.PHe0e,-self.T1,self.T1e)))
         print("************************************************************************") 
 
 #-------------------------------------------------------------------------------------
@@ -231,7 +232,7 @@ class Reduce():
         times = []
 
         print("\nStarting get_helium_parameters...")
-        print("Using {0} meV rep with PF={1}".format(ei,PF))
+        print(("Using {0} meV rep with PF={1}".format(ei,PF)))
         print("****************************************************")        
         for run in self.sample_runs[::2]:
             if self.NSF_first:
@@ -241,7 +242,7 @@ class Reduce():
                 NSF_run = run + 1
                 SF_run = run
 
-            print("Calculating P_He for runs NSF:{0} and SF:{1} at {2:<3.2f}meV with TOF {3:>6.0f} us".format(NSF_run,SF_run,ei,TOF))
+            print(("Calculating P_He for runs NSF:{0} and SF:{1} at {2:<3.2f}meV with TOF {3:>6.0f} us".format(NSF_run,SF_run,ei,TOF)))
 
 #load monitors and calculate flipping ratios
             NSF_monitors = LoadNexusMonitors("LET000{0}.nxs".format(NSF_run))
@@ -292,7 +293,7 @@ class Reduce():
         he_fit      = exp_decay(times, self.T1, self.PHe0)
         he_fit_ws   = CreateWorkspace(np.array(times),np.array(he_fit))
 
-        print("\nInitial Cell polarization P0={0:1.3f}+/-{1:1.3f} with lifetime T1={2:3.2f}+/-{3:1.2f}".format(self.PHe0,self.PHe0e,-self.T1,self.T1e))
+        print(("\nInitial Cell polarization P0={0:1.3f}+/-{1:1.3f} with lifetime T1={2:3.2f}+/-{3:1.2f}".format(self.PHe0,self.PHe0e,-self.T1,self.T1e)))
         print("************************************************************************") 
         
 #--------------------------------------------------------------------------
@@ -307,7 +308,7 @@ class Reduce():
 
             PF = next(PF_iter)
             print("****************************************")
-            print("\ncorrect_data: Correcting {0:<3.2f}meV rep with PF={1} \n".format(ei,PF))
+            print(("\ncorrect_data: Correcting {0:<3.2f}meV rep with PF={1} \n".format(ei,PF)))
             NSF_out = "PLET_{0}_{1:<3.2f}meV_NSF".format(self.label,ei)
             SF_out  = "PLET_{0}_{1:<3.2f}meV_SF".format(self.label,ei)   
 
@@ -339,7 +340,7 @@ class Reduce():
                     NSF_run = run + 1
                     SF_run = run
 
-                print("Correcting runs NSF:{0} and SF:{1} at {2:<3.2f}meV".format(NSF_run,SF_run,ei))
+                print(("Correcting runs NSF:{0} and SF:{1} at {2:<3.2f}meV".format(NSF_run,SF_run,ei)))
                 NSF_One2One = LoadNXSPE(self.name_format.format(NSF_run, ei))
                 SF_One2One  = LoadNXSPE(self.name_format.format(SF_run, ei))   
 
@@ -349,7 +350,7 @@ class Reduce():
                 PHe = self.PHe0 * np.exp(time / self.T1)
 
                 FAP = PF * np.tanh(opacity*(1.0/np.cos(gammaspace)*PHe))
-                print("After {0:1.2f} hours, cell polarization is {1:1.3f}".format(time,PHe))
+                print(("After {0:1.2f} hours, cell polarization is {1:1.3f}".format(time,PHe)))
                 flipping_ratio = (1.0 + FAP) / (1.0 - FAP)
                 transmission = np.exp(-opacity) * np.cosh(opacity * PHe)
                 Scharpf = (1.0 / (flipping_ratio - 1.0))

--- a/direct_inelastic/LET/absolute_sample_script_rebinning2014.py
+++ b/direct_inelastic/LET/absolute_sample_script_rebinning2014.py
@@ -1,6 +1,7 @@
 """      
 LET TRANSIENT REDUCTION SCRIPT MARCH 2014;
 """
+from __future__ import print_function
 
 # program to crunch down event mode from LET and produce output SPE files. 
 # Program can automatically find all incident energies in rep rate mode and write out spe files in the # form of LET'run no: +ei'.spe
@@ -82,7 +83,7 @@ if loadFreshWB:
                         
 for sample_run in run_no:     
     fname='LET000'+str(sample_run)+'.nxs'
-    print ' processing file ', fname
+    print(' processing file ', fname)
     #print ' Det Cal file:  ', iliad_reducer().det_cal_file;
     #w1 = iliad_reducer().load_data(run,'w1')
     w1 =Load(Filename=fname,OutputWorkspace='w1',LoadMonitors='1');
@@ -98,8 +99,8 @@ for sample_run in run_no:
     if len(ei) == 0: 
         # does not currently work properly due to generig loader problem in Mabtid. Needs changes in qtiGenie and Mantid fixes
         ei = find_chopper_peaks('w1_monitors');
-        print 'Found energies: ',ei
-    print 'Energies reduced are:'
+        print('Found energies: ',ei)
+    print('Energies reduced are:')
     print (ei)
 
     RenameWorkspace(InputWorkspace = 'w1',OutputWorkspace='w1_storage');
@@ -107,9 +108,9 @@ for sample_run in run_no:
                     
     #now loop around all energies for the run
     for ind,energy in enumerate(ei):
-        print "Reducing around energy: {0}".format(float(energy))
+        print("Reducing around energy: {0}".format(float(energy)))
         (energybin,tbin,t_elastic) = find_binning_range(energy,ebin);
-        print " Rebinning will be performed in the range: ",energybin
+        print(" Rebinning will be performed in the range: ",energybin)
         
         # if we calculate more then one energy, initial workspace will be used more then once. Is this enough for that?    
         #Rebin(InputWorkspace='w1',OutputWorkspace='w1reb',Params=tbin,PreserveEvents='1')                        
@@ -138,5 +139,5 @@ for sample_run in run_no:
         SaveNXSPE(InputWorkspace=ws_name,Filename=ws_name+'.nxspe');
 
 elapsed = (time.clock() - start)	
-print "Time to complete reduction : {0: 5.2f} min ".format(elapsed/60)
+print("Time to complete reduction : {0: 5.2f} min ".format(elapsed/60))
 

--- a/direct_inelastic/LET/iliad_example_abs.py
+++ b/direct_inelastic/LET/iliad_example_abs.py
@@ -1,6 +1,7 @@
 """
 The sample script for LET absolute units reduction
 """
+from __future__ import print_function
 from qtiGenie import *
 iliad_setup('let')
 
@@ -15,7 +16,7 @@ if len(save_dir) ==0 :
     config['defaultsave.directory']=os.getcwd()
     save_dir = config.getString('defaultsave.directory')
     
-print "Data will be saved into: ",save_dir
+print("Data will be saved into: ",save_dir)
 # map mask and cal file, again the values from Mantid, data search directories can be modified here
 config.appendDataSearchDir('/home/let/Desktop/LET_maps') 
 # data (raw or nxs) run files -- values from data search directories can be modified here
@@ -51,7 +52,7 @@ LoadRaw(Filename=str(wb),OutputWorkspace="wb_wksp") # load whitebeam
  
 for run in run_no:     #loop around runs
         fname='LET0000'+str(run)+'.nxs'
-        print ' processing file ', fname
+        print(' processing file ', fname)
         LoadEventNexus(Filename=fname,OutputWorkspace='w1',SingleBankPixelsOnly='0',LoadMonitors='1',MonitorsAsEvents='1')
         Rebin(InputWorkspace='w1_monitors',OutputWorkspace='mon',Params=[1000,100,90000])
         ExtractSingleSpectrum(InputWorkspace='mon',OutputWorkspace='mon',WorkspaceIndex='5')  #extract monitor 6
@@ -63,15 +64,15 @@ for run in run_no:     #loop around runs
         # this section finds all the transmitted incident energies
         if len(ei) == 0:
             ei = find_chopper_peaks('mon');
-        print ei
+        print(ei)
         if run == run_no[0]:
             ei = [ '%.2f' % elem for elem in ei ]
-        print 'energies transmitted are:'
+        print('energies transmitted are:')
         print (ei)
  
         
         for ind,energy in enumerate(ei):
-            print "Reducing around energy: {0}".format(float(energy))
+            print("Reducing around energy: {0}".format(float(energy)))
             (energybin,tbin,t_elastic) = find_binning_range(energy,ebin,25.,23.5,4.1,1.6);
 
             Rebin(InputWorkspace='w1',OutputWorkspace='w1reb',Params=tbin,PreserveEvents='1')        
@@ -80,7 +81,7 @@ for run in run_no:     #loop around runs
             energybin=[ebin[0]*energy,ebin[1]*energy,ebin[2]*energy]
             energybin = [ '%.4f' % elem for elem in energybin ] 
             ebinstring=str(energybin[0])+','+str(energybin[1])+','+str(energybin[2])
-            print ebinstring
+            print(ebinstring)
             argi={};
             argi['save_format']=''
             argi['fixei']=False
@@ -92,7 +93,7 @@ for run in run_no:     #loop around runs
             argi['hardmaskOnly']=file
 
 
-            for kk,val in argi.iteritems():
-                print "arguments :" ,kk,val
+            for kk,val in argi.items():
+                print("arguments :" ,kk,val)
             out=iliad("wb_wksp","w1reb",energy,ebinstring,mapping,MonoVanRun,**argi)
             SaveNXSPE(out,'LET'+str(run)+'_'+str(energy)+'mask_mev.nxspe') #

--- a/direct_inelastic/LET/mulpy_rep.py
+++ b/direct_inelastic/LET/mulpy_rep.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 #from mantid.simpleapi import *
 import numpy as np
@@ -190,7 +191,7 @@ def multi_rep(efocus, freq1, freqpr, chop2Phase=5, chop3=False):
     
     
     if chop3 == False:    
-        print "no chop 3"
+        print("no chop 3")
         dist=[7.83,8.4, 15.66, 23.5] #distance to each chopper in m choppers are in a logical order now
         freq = [freqpr/2., 10.0, freq1/2., freq1]# the frequencies of the choppers
         nslot=[6 ,1,6, 2]# number of slots in each chopper. assume that they are equally spaced
@@ -208,7 +209,7 @@ def multi_rep(efocus, freq1, freqpr, chop2Phase=5, chop3=False):
         radius = [290, 545, 290,290, 290] # radius in mm of each disk at centre of window
         numDisk = [2, 1,1, 1, 2]
     lam = np.sqrt(81.82/efocus) # convert from energy to wavelenth
-    print freq
+    print(freq)
     samp_det = 3.5 #sample to detector distance
     chop_samp = 1.5 # final chopper to sample distance
     source_rep = 10 # rep rate of source
@@ -256,7 +257,7 @@ def multi_rep(efocus, freq1, freqpr, chop2Phase=5, chop3=False):
     res,percent=calcRes(Ei,[chop_times[0][0],chop_times[-1][0]],dist[-1]-dist[0],chop_samp,samp_det)
     flux=calcFlux(Ei,freq1,percent)
     for idx in range(len(Ei)):
-        print "For Ei {:3.2f} meV, the resolution is {:6.2f} ueV or {:3.1f}% and the flux {:1.0f} n/cm^2/s".format(Ei[idx],res[idx]*1000,percent[idx]*100,flux[idx])
+        print("For Ei {:3.2f} meV, the resolution is {:6.2f} ueV or {:3.1f}% and the flux {:1.0f} n/cm^2/s".format(Ei[idx],res[idx]*1000,percent[idx]*100,flux[idx]))
     plotFrame(lines, chop_times,dist,chop_samp,samp_det,frac_ei,Ei)    
     return lines, chop_times
     #return chop_times

--- a/direct_inelastic/MAPS/MAPSReduction_Sample.py
+++ b/direct_inelastic/MAPS/MAPSReduction_Sample.py
@@ -1,6 +1,7 @@
 """ Sample MAPS reduction script """ 
 # Two rows necessary to run script outside of the mantid. You need also set up 
 # appropriate python path-es
+from __future__ import print_function
 import os
 #
 from mantid import *
@@ -172,15 +173,15 @@ def iliad_maps_crystal(runno,ei,wbvan,rebin_pars,monovan,sam_mass,sam_rmm,sum_ru
     #-----------------------------------------
     #
     filename_present = False;
-    for key,val in kwargs.items():
+    for key,val in list(kwargs.items()):
         if key == 'save_file_name':
             filename_present = True;
             if isinstance(runno, (list, tuple)) or isinstance(ei,(list, tuple)) :
-                  print "**************************************************************************************"
-                  print "*** WARNING: you can not set up single file name for list of files or list of energies"
-                  print "*** change ''set_custom_output_filename'' function, which returns lamda function used "
-                  print "*** to calculate file name as function of each incident energy and run number."
-                  print "**************************************************************************************"                  
+                  print("**************************************************************************************")
+                  print("*** WARNING: you can not set up single file name for list of files or list of energies")
+                  print("*** change ''set_custom_output_filename'' function, which returns lamda function used ")
+                  print("*** to calculate file name as function of each incident energy and run number.")
+                  print("**************************************************************************************")                  
                   continue
         if key == 'wait_for_file':
             rd.wait_for_file = kwargs['wait_for_file']

--- a/direct_inelastic/MAPS/PyChopMAPS_CalibWB.py
+++ b/direct_inelastic/MAPS/PyChopMAPS_CalibWB.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time as time
 import math
 import numpy
@@ -137,7 +138,7 @@ def calc_chop(ei,frequency,type):
 		#return
 		#titledata='MAPS C (100meV)'
 		err=error_message+instname
-		print err
+		print(err)
 		return (err,1)
 
     # Convert instrument parameters for the program (set as globals)
@@ -243,7 +244,7 @@ def van_var(*args):
 #!  chopper:
     tsqchp,ifail=tchop(omega, ei)
     ifail
-    if (ifail <> 0):
+    if (ifail != 0):
         tsqchp = 0.0
 
 
@@ -709,7 +710,7 @@ def chbmts(a,b,c,m,x):
 	y=(2.0*x-a-b)/(b-a)
 	y2=2.0*y
 
-	myrange=range(m-1,0,-1)
+	myrange=list(range(m-1,0,-1))
 	
 	#print('myrange')
 	#print(myrange)
@@ -960,7 +961,7 @@ def achop(ei,omega):
     groot=0
     if (gamm >= 4.00):
         f1=0.0
-        print 'no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz'
+        print('no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz')
     else:
         ierr=0
         if gamm <= 1.00:

--- a/direct_inelastic/MAPS/PyChopMAPS_CalibWB_OldModerator.py
+++ b/direct_inelastic/MAPS/PyChopMAPS_CalibWB_OldModerator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time as time
 import math
 import numpy
@@ -133,7 +134,7 @@ def calc_chop(ei,frequency,type):
 		#return
 		#titledata='MAPS C (100meV)'
 		err=error_message+instname
-		print err
+		print(err)
 		return (err,1)
 
     # Convert instrument parameters for the program (set as globals)
@@ -239,7 +240,7 @@ def van_var(*args):
 #!  chopper:
     tsqchp,ifail=tchop(omega, ei)
     ifail
-    if (ifail <> 0):
+    if (ifail != 0):
         tsqchp = 0.0
 
 
@@ -704,7 +705,7 @@ def chbmts(a,b,c,m,x):
 	y=(2.0*x-a-b)/(b-a)
 	y2=2.0*y
 
-	myrange=range(m-1,1,-1)
+	myrange=list(range(m-1,1,-1))
 	
 	#print(myrange)
 	#print(c)
@@ -952,7 +953,7 @@ def achop(ei,omega):
     groot=0
     if (gamm >= 4.00):
         f1=0.0
-        print 'no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz'
+        print('no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz')
     else:
         ierr=0
         if gamm <= 1.00:

--- a/direct_inelastic/MAPS/example_pychop_script_maps.py
+++ b/direct_inelastic/MAPS/example_pychop_script_maps.py
@@ -1,4 +1,5 @@
 #Example script for using PyChop
+from __future__ import print_function
 
 #All examples are for MAPS, but the same routines can be used for MARI on MERLIN
 

--- a/direct_inelastic/MARI/MARIReduction_Sample.py
+++ b/direct_inelastic/MARI/MARIReduction_Sample.py
@@ -282,7 +282,7 @@ class MARIReduction(ReductionWrapper):
                             ws_list = []
                             for id, ws_out in enumerate(red_ws):
                                 print('--------------------')
-                                print((ws_out.name()))
+                                print(ws_out.name())
                                 print('--------------------')
                                 ws_list.append('{0}_{1}_SQW'.format(out_ws_name, id))
                                 RenameWorkspace(InputWorkspace=ws_out.name()+'_SQW', OutputWorkspace=ws_list[-1])

--- a/direct_inelastic/MARI/MARIReduction_Sample.py
+++ b/direct_inelastic/MARI/MARIReduction_Sample.py
@@ -1,5 +1,6 @@
 #pylint: disable=invalid-name
 """ Sample MARI reduction script """
+from __future__ import print_function
 import os,sys
 from numpy import *
 from mantid import *
@@ -146,7 +147,7 @@ class MARIReduction(ReductionWrapper):
                 for ifake0, ifake1, ireal0, ireal1 in [[404, 440, 143, 179], [663, 699, 143, 179],
                                 [441, 470, 182, 211], [700, 729, 182, 211], [276, 371, 535, 630],
                                 [373, 378, 632, 637], [381, 386, 640, 645], [389, 394, 648, 653]]:
-                    for ifake, ireal in np.array([range(ifake0-1, ifake1), range(ireal0-1, ireal1)]).T:
+                    for ifake, ireal in np.array([list(range(ifake0-1, ifake1)), list(range(ireal0-1, ireal1))]).T:
                         y[ifake, :] = y[ireal, :]
                         e[ifake, :] = e[ireal, :]
                 # Masking is messed up if we use this fake white beam so put masks here directly...
@@ -281,7 +282,7 @@ class MARIReduction(ReductionWrapper):
                             ws_list = []
                             for id, ws_out in enumerate(red_ws):
                                 print('--------------------')
-                                print(ws_out.name())
+                                print((ws_out.name()))
                                 print('--------------------')
                                 ws_list.append('{0}_{1}_SQW'.format(out_ws_name, id))
                                 RenameWorkspace(InputWorkspace=ws_out.name()+'_SQW', OutputWorkspace=ws_list[-1])
@@ -407,14 +408,14 @@ def iliad_mari(runno,ei,wbvan,monovan,sam_mass,sam_rmm,sum_runs=False,**kwargs):
         prop_man.monovan_run=None
 
     outws = None
-    for key,val in kwargs.items():
+    for key,val in list(kwargs.items()):
         if key == 'save_file_name':
             if isinstance(runno, (list, tuple)) or isinstance(ei,(list, tuple)) :
-                print "**************************************************************************************"
-                print "*** WARNING: you can not set up single file name for list of files or list of energies"
-                print "*** change ''set_custom_output_filename'' function, which returns lamda function used "
-                print "*** to calculate file name as function of each incident energy and run number."
-                print "**************************************************************************************"
+                print("**************************************************************************************")
+                print("*** WARNING: you can not set up single file name for list of files or list of energies")
+                print("*** change ''set_custom_output_filename'' function, which returns lamda function used ")
+                print("*** to calculate file name as function of each incident energy and run number.")
+                print("**************************************************************************************")
                 continue
         if key == 'wait_for_file':
              rd.wait_for_file = kwargs['wait_for_file']
@@ -619,10 +620,10 @@ def iliad_dos(runno, wbvan, ei=None, monovan=None, sam_mass=0, sam_rmm=0, sum_ru
         else:
             runs_dict = {'MAR{}'.format(run): {temperature: {'data':run}} for run in runno}
             if monovan and sam_mass:
-                for ky in runs_dict.keys():
+                for ky in list(runs_dict.keys()):
                     runs_dict[ky]['sam_mass'] = sam_mass
             if monovan and sam_rmm:
-                for ky in runs_dict.keys():
+                for ky in list(runs_dict.keys()):
                     runs_dict[ky]['sam_rmm'] = sam_rmm
             if 'background' in kwargs:
                 background = kwargs.pop('background')
@@ -661,7 +662,7 @@ def iliad_dos(runno, wbvan, ei=None, monovan=None, sam_mass=0, sam_rmm=0, sum_ru
                     SmoothData(ws_dos, nsmooth, OutputWorkspace=ws_dos.name()+'_smooth')
                     if save_text:
                         SaveAscii(ws_dos.name()+'_smooth', ws_dos.name()+'_smooth.txt', Separator='Space')
-            if 'background' in ws_dict[sam][tt].keys():
+            if 'background' in list(ws_dict[sam][tt].keys()):
                 bkg_ei = [ws.getEFixed(1) for ws in ws_dict[sam][tt]['background']]
                 id_bkg_ei = [np.argsort([np.abs(ei1-ei0) for ei1 in bkg_ei])[0] for ei0 in def_ei]
                 bkg_ws = [ws_dict[sam][tt]['background'][id_bkg_ei[ii]] for ii in range(len(bkg_ei))]

--- a/direct_inelastic/MARI/MARIReduction_SampleAbs.py
+++ b/direct_inelastic/MARI/MARIReduction_SampleAbs.py
@@ -351,7 +351,7 @@ class MARIReduction(ReductionWrapper):
                             ws_list = []
                             for id, ws_out in enumerate(red_ws):
                                 print('--------------------')
-                                print((ws_out.name()))
+                                print(ws_out.name())
                                 print('--------------------')
                                 ws_list.append('{0}_{1}_SQW'.format(out_ws_name, id))
                                 RenameWorkspace(InputWorkspace=ws_out.name()+'_SQW', OutputWorkspace=ws_list[-1])

--- a/direct_inelastic/MARI/MARIReduction_SampleAbs.py
+++ b/direct_inelastic/MARI/MARIReduction_SampleAbs.py
@@ -1,5 +1,6 @@
 #pylint: disable=invalid-name
 """ Sample MARI reduction script """
+from __future__ import print_function
 import os,sys
 from numpy import *
 from mantid import *
@@ -215,7 +216,7 @@ class MARIReduction(ReductionWrapper):
                 for ifake0, ifake1, ireal0, ireal1 in [[404, 440, 143, 179], [663, 699, 143, 179],
                                 [441, 470, 182, 211], [700, 729, 182, 211], [276, 371, 535, 630],
                                 [373, 378, 632, 637], [381, 386, 640, 645], [389, 394, 648, 653]]:
-                    for ifake, ireal in np.array([range(ifake0-1, ifake1), range(ireal0-1, ireal1)]).T:
+                    for ifake, ireal in np.array([list(range(ifake0-1, ifake1)), list(range(ireal0-1, ireal1))]).T:
                         y[ifake, :] = y[ireal, :]
                         e[ifake, :] = e[ireal, :]
                 # Masking is messed up if we use this fake white beam so put masks here directly...
@@ -350,7 +351,7 @@ class MARIReduction(ReductionWrapper):
                             ws_list = []
                             for id, ws_out in enumerate(red_ws):
                                 print('--------------------')
-                                print(ws_out.name())
+                                print((ws_out.name()))
                                 print('--------------------')
                                 ws_list.append('{0}_{1}_SQW'.format(out_ws_name, id))
                                 RenameWorkspace(InputWorkspace=ws_out.name()+'_SQW', OutputWorkspace=ws_list[-1])
@@ -508,14 +509,14 @@ def iliad_mari(runno,ei,wbvan,monovan,sam_mass,sam_rmm,sum_runs=False,**kwargs):
         prop_man.monovan_run=None
 
     outws = None
-    for key,val in kwargs.items():
+    for key,val in list(kwargs.items()):
         if key == 'save_file_name':
             if isinstance(runno, (list, tuple)) or isinstance(ei,(list, tuple)) :
-                print "**************************************************************************************"
-                print "*** WARNING: you can not set up single file name for list of files or list of energies"
-                print "*** change ''set_custom_output_filename'' function, which returns lamda function used "
-                print "*** to calculate file name as function of each incident energy and run number."
-                print "**************************************************************************************"
+                print("**************************************************************************************")
+                print("*** WARNING: you can not set up single file name for list of files or list of energies")
+                print("*** change ''set_custom_output_filename'' function, which returns lamda function used ")
+                print("*** to calculate file name as function of each incident energy and run number.")
+                print("**************************************************************************************")
                 continue
         if key == 'wait_for_file':
              rd.wait_for_file = kwargs['wait_for_file']
@@ -720,10 +721,10 @@ def iliad_dos(runno, wbvan, ei=None, monovan=None, sam_mass=0, sam_rmm=0, sum_ru
         else:
             runs_dict = {'MAR{}'.format(run): {temperature: {'data':run}} for run in runno}
             if monovan and sam_mass:
-                for ky in runs_dict.keys():
+                for ky in list(runs_dict.keys()):
                     runs_dict[ky]['sam_mass'] = sam_mass
             if monovan and sam_rmm:
-                for ky in runs_dict.keys():
+                for ky in list(runs_dict.keys()):
                     runs_dict[ky]['sam_rmm'] = sam_rmm
             if 'background' in kwargs:
                 background = kwargs.pop('background')
@@ -762,7 +763,7 @@ def iliad_dos(runno, wbvan, ei=None, monovan=None, sam_mass=0, sam_rmm=0, sum_ru
                     SmoothData(ws_dos, nsmooth, OutputWorkspace=ws_dos.name()+'_smooth')
                     if save_text:
                         SaveAscii(ws_dos.name()+'_smooth', ws_dos.name()+'_smooth.txt', Separator='Space')
-            if 'background' in ws_dict[sam][tt].keys():
+            if 'background' in list(ws_dict[sam][tt].keys()):
                 bkg_ei = [ws.getEFixed(1) for ws in ws_dict[sam][tt]['background']]
                 id_bkg_ei = [np.argsort([np.abs(ei1-ei0) for ei1 in bkg_ei])[0] for ei0 in def_ei]
                 bkg_ws = [ws_dict[sam][tt]['background'][id_bkg_ei[ii]] for ii in range(len(bkg_ei))]

--- a/direct_inelastic/MARI/MariChop/MARIChopGUI.py
+++ b/direct_inelastic/MARI/MariChop/MARIChopGUI.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 from MARIChopUI import Ui_MainWindow
 from PyQt4 import QtCore, uic,QtGui
@@ -41,20 +42,20 @@ class MainWindow(QtGui.QMainWindow):
 		self.inst='merlin'
 	def mari(self):
 		self.inst='mari'
-		print 'MARI selected'
+		print('MARI selected')
 	
 	def gd(self):
 		self.chop='g'
-		print 'Gd chopper selected'
+		print('Gd chopper selected')
 	def sloppy(self):
 		self.chop='s'
-		print 'Sloppy chopper selected'
+		print('Sloppy chopper selected')
 	def a(self):
 		self.chop='a'
-		print 'A chopper selected'
+		print('A chopper selected')
 	def r(self):
 		self.chop='r'
-		print 'Relaxed chopper selected'
+		print('Relaxed chopper selected')
 		
 	def ei(self):
 		self.ei=float(self.ui.ei.text())
@@ -78,7 +79,7 @@ class MainWindow(QtGui.QMainWindow):
 			en_lo=1
 			eps_min=en_lo
 			eps_max=fac*self.ei +(1-fac)*en_lo
-			eeps=range(int(eps_min),int(eps_max),1)
+			eeps=list(range(int(eps_min),int(eps_max),1))
 			dat=list(van)
 			dat.reverse()
 			CreateWorkspace(OutputWorkspace='Energy transfer resolution at'+str(freq)+'Hz',DataX=eeps,DataY=dat,DataE=list(van*0),WorkspaceTitle='Resolution at'+str(self.ei)+'meV',UnitX='Energy Transfer [meV]',YUnitLabel='resolution [meV]')

--- a/direct_inelastic/MARI/MariChop/MariChop.py
+++ b/direct_inelastic/MARI/MariChop/MariChop.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time as time
 import math
 import numpy
@@ -38,39 +39,39 @@ def setchoptype(inst_name,type):
 	chop_type=type
 	if inst_name=='mari' or inst_name=='mar' or inst_name=='MAR'or inst_name=='MARI':
 		instname='mar'
-		print 'setup for MARI'
+		print('setup for MARI')
 		if type == 'c':
 			chop_par=[1.520, 0.550, 49.00,  580.00, 0.00, 0.00]
-			print 'MARI C (100meV) chopper chosen'
+			print('MARI C (100meV) chopper chosen')
 			titledata='MARI C (100meV)'
 		elif type == 'g':
 			chop_par=[0.38, 0.02, 10.00,  800.00, 0.00, 0.00]
-			print 'MARI G (Gd pack) chopper chosen'
+			print('MARI G (Gd pack) chopper chosen')
 			titledata='MARI G (Gd pack)'
 		elif type == 's':
 			chop_par=[2.280, 0.550, 49.00, 1300.00, 0.00, 0.00]
-			print 'MARI S (sloppy) chopper chosen'
+			print('MARI S (sloppy) chopper chosen')
 			titledata='MARI S (sloppy)'
 		elif type == 'b':
 			chop_par= [1.140, 0.550, 49.00,  820.00, 0.00, 0.00]
-			print 'MARI B (200meV) chopper chosen'
+			print('MARI B (200meV) chopper chosen')
 			titledata='MARI B (200meV)'
 		elif type == 'a':
 			chop_par= [0.760, 0.550, 49.00, 1300.00, 0.00, 0.00]
-			print 'MARI A (500meV) chopper chosen'
+			print('MARI A (500meV) chopper chosen')
 			titledata='MARI A (500meV)'
 		elif chop_type == 'r':
 			chop_par= [1.143, 0.550, 49.00, 1300, 0.00, 0.00]
-			print 'MARI R (500meV) chopper chosen'
+			print('MARI R (500meV) chopper chosen')
 			titledata='MARI R (500meV)'
 		else:
-			print 'Chopper type not recognised'
+			print('Chopper type not recognised')
 
 	if instname=='maps' or instname=='map' or instname=='MAP'or instname=='MAPS':
 		instname='map'
-		print 'setup for MAPS'
+		print('setup for MAPS')
 		if type == 'c':
-			print 'MAPS C (100meV) not available'
+			print('MAPS C (100meV) not available')
 			return
 			titledata='MAPS C (100meV)'
 		elif type == 's':
@@ -79,36 +80,36 @@ def setchoptype(inst_name,type):
 			titledata='MAPS S (sloppy)'
 		elif type == 'b':
 			chop_par= [ 1.8120,0.5340,49.00,  920.00, 0.00, 0.0]
-			print 'MAPS B (200meV) chopper chosen'
+			print('MAPS B (200meV) chopper chosen')
 			titledata='MAPS B (200meV)'
 		elif type == 'a':
 			chop_par= [1.0870,0.5340,49.00, 1300.00, 0.00, 0.00]
-			print 'MAPS A (500meV) chopper chosen'
+			print('MAPS A (500meV) chopper chosen')
 			titledata='MAPS A (500meV)'
 		else:
 			disp('Chopper type not recognised')
 	if instname=='MER' or instname=='mer' or instname=='MERLIN'or instname=='merlin':
 		instname='mer'
-		print 'setup for MERLIN'
+		print('setup for MERLIN')
 		if type == 'c':
 			chop_par=[ 1.710, 0.550, 49.00,  580.00, 0.00, 0.00 ]
-			print 'HET C (100meV) chopper chosen'
+			print('HET C (100meV) chopper chosen')
 			titledata='HET C (100meV)'
 		elif type == 'd':
 			chop_par=[ 1.520, 0.550, 49.00,  410.00, 0.00, 0.00 ]
-			print 'HET D (50meV) chopper chosen'
+			print('HET D (50meV) chopper chosen')
 			titledata='HET D (50meV)'
 		elif type == 's':
 			chop_par=[2.280, 0.550, 49.00, 1300.00, 0.00, 0.00 ]
-			print 'HET S (sloppy) chopper chosen'
+			print('HET S (sloppy) chopper chosen')
 			titledata='HET S (sloppy)'
 		elif type == 'b':
 			chop_par= [1.290, 0.550, 49.00,  920.00, 0.00, 0.00 ]
-			print 'HET B (200meV) chopper chosen'
+			print('HET B (200meV) chopper chosen')
 			titledata='HET B (200meV)'
 		elif type == 'a':
 			chop_par= [0.760, 0.550, 49.00, 1300.00, 0.00, 0.0 ]
-			print 'HET A (500meV) chopper chosen'
+			print('HET A (500meV) chopper chosen')
 			titledata='HET A (500meV)'
 		else:
 			disp('Chopper type not recognised') 
@@ -273,8 +274,8 @@ def calculate(ei,frequency,**kwargs):
 	en_hi=ei*1.1
 	
 	
-	if kwargs.has_key('freq_dep'):
-		freq=range(50,650,50)
+	if 'freq_dep' in kwargs:
+		freq=list(range(50,650,50))
 		van_el = numpy.zeros(len(freq))
 		flux = numpy.zeros(len(freq))
 		err = numpy.zeros(len(freq)) #for mantid output
@@ -286,27 +287,27 @@ def calculate(ei,frequency,**kwargs):
 		van_el,van,flux=calc_chop(ei,omega,en_lo,en_hi)
 
 
-	if kwargs.has_key('all') and kwargs.get('all')==True:
+	if 'all' in kwargs and kwargs.get('all')==True:
 		return van_el,van,flux
-	if kwargs.has_key('resolution') and kwargs.get('resolution')==True:
-		if kwargs.has_key('plot') and kwargs.get('plot')==True:
+	if 'resolution' in kwargs and kwargs.get('resolution')==True:
+		if 'plot' in kwargs and kwargs.get('plot')==True:
 		#plot data
 			#recreate x range
 			fac=.99
 			en_lo=1
 			eps_min=en_lo
 			eps_max=fac*ei +(1-fac)*en_lo
-			eeps=range(int(eps_min),int(eps_max),1)
+			eeps=list(range(int(eps_min),int(eps_max),1))
 			dat=list(van)
 			dat.reverse()
 			CreateWorkspace(OutputWorkspace="Resolution",DataX=eeps,DataY=dat,DataE=list(van*0),VerticalAxisValues="data",WorkspaceTitle='Resolution at'+str(ei)+'meV')
 			plotSpectrum('Resolution',0)
 			return
 		return van
-	if kwargs.has_key('flux') and kwargs.get('flux')==True:
+	if 'flux' in kwargs and kwargs.get('flux')==True:
 		return van_el,flux
-	if kwargs.has_key('freq_dep') and kwargs.get('freq_dep')==True:
-		if kwargs.has_key('plot') and kwargs.get('plot')==True:
+	if 'freq_dep' in kwargs and kwargs.get('freq_dep')==True:
+		if 'plot' in kwargs and kwargs.get('plot')==True:
 			CreateWorkspace(OutputWorkspace='Flux',DataX=freq,DataY=list(flux),DataE=list(err),VerticalAxisValues="data",WorkspaceTitle='Flux at'+str(ei)+'meV')
 			plotSpectrum('Flux',0)
 			CreateWorkspace(OutputWorkspace="Resolution",DataX=freq,DataY=list(van_el),DataE=list(err),VerticalAxisValues="data",WorkspaceTitle='Resolution at'+str(ei)+'meV')
@@ -323,7 +324,7 @@ def calc_chop(ei,omega,en_lo,en_hi):
 	convert = 2.3548200
 	# calcs flux and resoltion over a range
 	# en_lo some lower range for energy for the calculation
-	print 'energy lower', en_lo
+	print('energy lower', en_lo)
 	v_lo = max( 437.391580*math.sqrt((en_lo)), 2.00*omega/(1.00/rho + (2.00*pslit/radius**2)) )
 	g_lo = max( -4.00, (2.00*radius**2/pslit)*(1.00/rho - 2.00*omega/v_lo) )
 	v_hi = 437.391580*math.sqrt((en_hi))
@@ -345,14 +346,14 @@ def calc_chop(ei,omega,en_lo,en_hi):
 		#subplot(2,1,2), xlabel('Ei [mev]'), ylabel('Vanadium width [meV]')
 		#else
 		#For a single ei always display the resolution
-		print 'Flux at sample position at ',ei,'meV',int(omega/(2*math.pi)), 'Hz =',int(flux),'ns^-1'
+		print('Flux at sample position at ',ei,'meV',int(omega/(2*math.pi)), 'Hz =',int(flux),'ns^-1')
 		# calc resolution as a function of energy trans
-		print 'Resolution of elastic line at ',int(omega/(2*math.pi)), 'Hz = ',van_el, 'meV = ',(van_el/ei)*100, '%'
+		print('Resolution of elastic line at ',int(omega/(2*math.pi)), 'Hz = ',van_el, 'meV = ',(van_el/ei)*100, '%')
 		fac=.99
 		en_lo=1
 		eps_min=en_lo
 		eps_max=fac*ei +(1-fac)*en_lo
-		eeps=range(int(eps_min),int(eps_max),1)
+		eeps=list(range(int(eps_min),int(eps_max),1))
 		van=numpy.zeros(numpy.size(eeps))
 		for i in range(numpy.size(eeps)):
 			etrans=ei-eeps[i]
@@ -412,7 +413,7 @@ def van_var(*args):
 #!  chopper:
 	tsqchp,ifail=tchop(omega, ei)
 	ifail
-	if (ifail <> 0): 
+	if (ifail != 0): 
 		tsqchp = 0.0
 
 
@@ -605,9 +606,9 @@ def sam_flux(ei,omega):
 	global imod, sx, sy, sz, isam, gam, ia, ix, idet, dd, tbin, titledata
 	flux=[] 
 	flux1=flux_calc(ei) 
-	print 'flux ', flux1
+	print('flux ', flux1)
 	area=achop(ei,omega)
-	print 'area', area 
+	print('area', area) 
 	#for j in range(len(ei)):
 	flux = 84403.060*ei*(flux1/math.cos(thetam))*(area/dslat)*(wa*ha)/(x0*(x1+xa)**2) 
 	
@@ -750,7 +751,7 @@ def achop(ei,omega):
 	vela=437.3920*math.sqrt(ei) 
 	gamm=( 2.00*(R1**2)/p1 ) * abs(1.00/rho1 - 2.00*w1/vela) 
 	
-	print 'gamm',gamm
+	print('gamm',gamm)
 # !  Find regime and calculate variance:
 # ! -------------------------------------
 	
@@ -759,9 +760,9 @@ def achop(ei,omega):
 	
 	if gamm >= 4.00:
 		f1=0.0
-		print 'no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz' 
+		print('no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz') 
 		area=( (p1**2)/(2.00*R1*w1) ) * f1 
-		print 'area', area		
+		print('area', area)		
 	elif gamm <= 1.00:
 		f1=1.00-(gamm**2)/6.00 
 		area=( (p1**2)/(2.00*R1*w1) ) * f1 
@@ -769,11 +770,11 @@ def achop(ei,omega):
 		groot=math.sqrt(gamm) 
 		f1=groot*((groot-2.00)**2)*(groot+4.00)/6.00 
 		area=( (p1**2)/(2.00*R1*w1) ) * f1 
-		print 'here'
+		print('here')
 
 	
 	
-	print 'area', area
+	print('area', area)
 	return area
 
 def frange(limit1, limit2 = None, increment = 1.):

--- a/direct_inelastic/MARI/PyChopMARI_CalibWB.py
+++ b/direct_inelastic/MARI/PyChopMARI_CalibWB.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time as time
 import math
 import numpy
@@ -158,7 +159,7 @@ def calc_chop(ei,frequency,type):
                 flux_fudge=3
             else:
                 err_mess=error_message+instname
-                print err_mess
+                print(err_mess)
                 return (err_mess,1)
 
     # Convert instrument parameters for the program (set as globals)
@@ -264,7 +265,7 @@ def van_var(*args):
 #!  chopper:
     tsqchp,ifail=tchop(omega, ei)
     ifail
-    if (ifail <> 0):
+    if (ifail != 0):
         tsqchp = 0.0
 
 
@@ -730,7 +731,7 @@ def chbmts(a,b,c,m,x):
 	y=(2.0*x-a-b)/(b-a)
 	y2=2.0*y
 
-	myrange=range(m-1,0,-1)
+	myrange=list(range(m-1,0,-1))
 	
 	#print('myrange')
 	#print(myrange)
@@ -980,7 +981,7 @@ def achop(ei,omega):
     groot=0
     if (gamm >= 4.00):
         f1=0.0
-        print 'no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz'
+        print('no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz')
     else:
         ierr=0
         if gamm <= 1.00:

--- a/direct_inelastic/MARI/example_pychop_script_mari.py
+++ b/direct_inelastic/MARI/example_pychop_script_mari.py
@@ -1,4 +1,5 @@
 #Example script for using PyChop
+from __future__ import print_function
 
 #All examples are for MAPS, but the same routines can be used for MARI on MERLIN
 

--- a/direct_inelastic/MARI/gen_mask_mari.py
+++ b/direct_inelastic/MARI/gen_mask_mari.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.simpleapi import mtd, Load, CreateWorkspace, LoadInstrument
 import numpy as np
 from six import string_types
@@ -58,4 +59,4 @@ def map_mask_specnum(spec_list, white_run, quiet_run=None):
             raise RuntimeError('Wrong spectra')
     return out_list
 
-print(map_mask_specnum([535, 647, 709], 25779, 26190))
+print((map_mask_specnum([535, 647, 709], 25779, 26190)))

--- a/direct_inelastic/MARI/gen_mask_mari.py
+++ b/direct_inelastic/MARI/gen_mask_mari.py
@@ -59,4 +59,4 @@ def map_mask_specnum(spec_list, white_run, quiet_run=None):
             raise RuntimeError('Wrong spectra')
     return out_list
 
-print((map_mask_specnum([535, 647, 709], 25779, 26190)))
+print(map_mask_specnum([535, 647, 709], 25779, 26190))

--- a/direct_inelastic/MARI/iliad_python.py
+++ b/direct_inelastic/MARI/iliad_python.py
@@ -5,6 +5,7 @@ This is old script left here for historical reasons.
 qtiGenie is not used for reduction any more. 
 
 """
+from __future__ import print_function
 from qtiGenie import *
 from mantid.simpleapi import *
 from mantid import config
@@ -22,7 +23,7 @@ if len(save_dir) ==0 :
     config['defaultsave.directory']=os.getcwd()
     save_dir = config.getString('defaultsave.directory')
     
-print "Data will be saved into: ",save_dir
+print("Data will be saved into: ",save_dir)
 # map mask and cal file, again the values from Mantid, data search directories can be modified here
 config.appendDataSearchDir('/usr/local/mprogs/InstrumentFiles/mari') 
 # data (raw or nxs) run files -- values from data search directories can be modified here

--- a/direct_inelastic/MERLIN/Iiad_event_autoreduce.py
+++ b/direct_inelastic/MERLIN/Iiad_event_autoreduce.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from qtiGenie import *
 import datetime
 iliad_setup('merlin')
@@ -72,19 +73,19 @@ for run in run_no:     #loop around runs
         complete_file=FileFinder.getFullPath(short_final)
         interm_file = FileFinder.getFullPath(short_interm)
         if (len(complete_file) > 0 or len(interm_file ) > 0) or ignore_wait:
-            print "------------------------------------------------------------------------"
+            print("------------------------------------------------------------------------")
             if len(complete_file)>0:
                   aok=1
-                  print "*** processing final file {0}".format(complete_file)
+                  print("*** processing final file {0}".format(complete_file))
                   Load(Filename=complete_file,OutputWorkspace='w1',SingleBankPixelsOnly='0',LoadMonitors='1',MonitorsAsEvents='0',Precount=True)
             else:
-                  print "*** processing intermediate file {0}".format(interm_file)
+                  print("*** processing intermediate file {0}".format(interm_file))
                   # This should be uncommented instead generic load to work with histogram-mode nexus file
                   #w1=LoadNexus(interm_file)
                   #w1_monitors=LoadNexusMonitors(interm_file)
                   w1,w1_monitors=Load(Filename=interm_file,SingleBankPixelsOnly='0',LoadMonitors='1',MonitorsAsEvents='0',Precount=True)
                   run_count+=1
-                  print "------------------------------------------------------------------------"
+                  print("------------------------------------------------------------------------")
  
             AddSampleLog(Workspace='w1',LogName='run_number',LogText=str(run),LogType='Number') #only have to do this as run_number is passed to workspace for event files
 
@@ -98,7 +99,7 @@ for run in run_no:     #loop around runs
             # this section finds all the transmitted incident energies if you have not provided them
             if len(ei) == 0:  #-- not tested here -- should be unit test for that. 
                 ei = find_chopper_peaks('w1_monitors');       
-                print 'Energies transmitted are:',
+                print('Energies transmitted are:', end=' ')
             print (ei)
 
             RenameWorkspace(InputWorkspace = 'w1',OutputWorkspace='w1_storage');
@@ -107,9 +108,9 @@ for run in run_no:     #loop around runs
             #now loop around all energies for the run
             result =[];
             for ind,energy in enumerate(ei):
-                print float(energy)
+                print(float(energy))
                 (energybin,tbin,t_elastic) = find_binning_range(energy,ebin);
-                print " Rebinning will be performed in the range: ",energybin
+                print(" Rebinning will be performed in the range: ",energybin)
                 # if we calculate more then one energy, initial workspace will be used more then once
                 if ind <len(ei)-1:
                     CloneWorkspace(InputWorkspace = 'w1_storage',OutputWorkspace='w1')
@@ -144,15 +145,15 @@ for run in run_no:     #loop around runs
                 ws_name = 'MER{0}_ei{1:3.1f}mev'.format(run,energy);
                 #RenameWorkspace(InputWorkspace=out,OutputWorkspace=ws_name);
                 fileName=ws_name+'.nxspe';
-                print 'Saving results into file {0}'.format(fileName)
+                print('Saving results into file {0}'.format(fileName))
                 SaveNXSPE(InputWorkspace=out,Filename=fileName)
 
 
                 elapsed = (time.clock() - start)
-                print "Time to process run {0} with energy {1} is: {2} sec".format(run,energy,elapsed)
+                print("Time to process run {0} with energy {1} is: {2} sec".format(run,energy,elapsed))
         else:
           aok=0
-          print " waiting for files {0} or {1} to appear on the data search path".format(short_interm,short_final)
+          print(" waiting for files {0} or {1} to appear on the data search path".format(short_interm,short_final))
           Pause(900)
 
 

--- a/direct_inelastic/MERLIN/MERLINReduction_2018_2WithPerformance.py
+++ b/direct_inelastic/MERLIN/MERLINReduction_2018_2WithPerformance.py
@@ -34,7 +34,7 @@ class MERLINReduction(ReductionWrapper_withPerformance):
        # the range of files to reduce. This range ignored when deployed from autoreduction,
        # unless you going to sum these files. 
        # The range of numbers or run number is used when you run reduction from PC.
-       prop['sample_run'] =  range(41624,42308) #range(41624,42308)#range(24003,24011) # 'MER23700.n001'
+       prop['sample_run'] =  list(range(41624,42308)) #range(41624,42308)#range(24003,24011) # 'MER23700.n001'
        #prop['sample_run'] =  range(41624,41700)#range(24003,24011) # 'MER23700.n001'
        prop['wb_run'] = 40954 #'40954.raw'
        #

--- a/direct_inelastic/MERLIN/MERLINReduction_SampleAbs.py
+++ b/direct_inelastic/MERLIN/MERLINReduction_SampleAbs.py
@@ -283,7 +283,7 @@ class MERLINReduction(ReductionWrapper):
             n_spectra = len(check_spectra)
             if n_spectra == 0:
                 n_specra = corrections.getNumberHistograms()
-            mpl.plotSpectrum(corrections,range(0,n_spectra))
+            mpl.plotSpectrum(corrections,list(range(0,n_spectra)))
         #
         return corrections
 

--- a/direct_inelastic/MERLIN/PyChopMERLIN_CalibWB.py
+++ b/direct_inelastic/MERLIN/PyChopMERLIN_CalibWB.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time as time
 import math
 import numpy
@@ -149,7 +150,7 @@ def calc_chop(ei,frequency,type):
 			titledata='MERLIN G'
 		else:
 			err=error_message+instname
-			print err
+			print(err)
 			return (err,1)
 
     # Convert instrument parameters for the program (set as globals)
@@ -255,7 +256,7 @@ def van_var(*args):
 #!  chopper:
     tsqchp,ifail=tchop(omega, ei)
     ifail
-    if (ifail <> 0):
+    if (ifail != 0):
         tsqchp = 0.0
 
 
@@ -721,7 +722,7 @@ def chbmts(a,b,c,m,x):
 	y=(2.0*x-a-b)/(b-a)
 	y2=2.0*y
 
-	myrange=range(m-1,0,-1)
+	myrange=list(range(m-1,0,-1))
 	
 	#print('myrange')
 	#print(myrange)
@@ -971,7 +972,7 @@ def achop(ei,omega):
     groot=0
     if (gamm >= 4.00):
         f1=0.0
-        print 'no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz'
+        print('no transmission at ', ei, 'meV at ',omega/(2*math.pi), 'Hz')
     else:
         ierr=0
         if gamm <= 1.00:

--- a/direct_inelastic/MERLIN/adr_cycle2013_3.py
+++ b/direct_inelastic/MERLIN/adr_cycle2013_3.py
@@ -1,6 +1,7 @@
 """
 sample Direct inelastic reduction for MERLIN performed in absolute units
 """
+from __future__ import print_function
 from qtiGenie import *
 #from PySlice2 import *
 
@@ -17,7 +18,7 @@ if len(save_dir) ==0 :
     config['defaultsave.directory']=os.getcwd()
     save_dir = config.getString('defaultsave.directory')
     
-print "Data will be saved into: ",save_dir
+print("Data will be saved into: ",save_dir)
 # map mask and cal file, again the values from Mantid, data search directories can be modified here
 config.appendDataSearchDir('/home/merlin/mprogs/InstrumentFiles/merlin') 
 # data (raw or nxs) run files -- values from data search directories can be modified here
@@ -60,7 +61,7 @@ for runfile in runs:
     w1=iliad("wb_wksp","run_wksp",ei,rebin_params,mapfile,MonoVanRun,**params)
 
     SaveNXSPE('w1',save_file)
-print "All done"
+print("All done")
 
 
 

--- a/direct_inelastic/MERLIN/calibration/adjustdet.py
+++ b/direct_inelastic/MERLIN/calibration/adjustdet.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import numpy as np
 import scipy
@@ -81,25 +82,25 @@ def adjust_detector_MER(fit_res,det_source_file):
             fit_pos = ((np.array(fit_par)-256)/512)*tube_len_long
             true_pos = [-0.48, -0.21, -0.15, 0, 0.15, 0.28, 0.48]       #fractional positions of stripes taken from calibration bin
             true_pos = np.array(true_pos)*tube_len_long
-            ideal_det_pos = -0.5*tube_len_long + 0.5*xbin_long + np.array(range(0,nDet))*xbin_long
+            ideal_det_pos = -0.5*tube_len_long + 0.5*xbin_long + np.array(list(range(0,nDet)))*xbin_long
         elif tube_type==1:
             fit_par = [tub_fit['peak4'][tub_num],tub_fit['peak5'][tub_num],tub_fit['tube_end'][tub_num]]
             true_pos = [0.15, 0.28, 0.48]       #fractional positions of stripes taken from calibration bin
             true_pos = np.array(true_pos)*tube_len_long 
             fit_pos = high_short_tube_pos + ((np.array(fit_par))/512)*tube_len_short
-            ideal_det_pos = high_short_tube_pos + 0.5*xbin_short + np.array(range(0,nDet))*xbin_short
+            ideal_det_pos = high_short_tube_pos + 0.5*xbin_short + np.array(list(range(0,nDet)))*xbin_short
         elif tube_type==2:
             fit_par = [tub_fit['tube_start'][tub_num],tub_fit['peak1'][tub_num],tub_fit['peak2'][tub_num]]
             true_pos = [-0.48, -0.21, -0.15]       #fractional positions of stripes taken from calibration bin
             true_pos = np.array(true_pos)*tube_len_long
             fit_pos = low_short_tube_pos + ((np.array(fit_par))/512)*tube_len_short
-            ideal_det_pos = low_short_tube_pos + 0.5*xbin_short + np.array(range(0,nDet))*xbin_short
+            ideal_det_pos = low_short_tube_pos + 0.5*xbin_short + np.array(list(range(0,nDet)))*xbin_short
         else:
             error('Adjust Detectors - Invalid argument')
         
-        print 'Tube N',tub_num,'With ID: ',tube_id,' has peaks fitted at: ',fit_par
-        print 'True peaks positions: ',fit_pos
-        print 'Stripes positions: '  ,true_pos
+        print('Tube N',tub_num,'With ID: ',tube_id,' has peaks fitted at: ',fit_par)
+        print('True peaks positions: ',fit_pos)
+        print('Stripes positions: '  ,true_pos)
         
         z_new = tube_correction(true_pos,fit_pos,ideal_det_pos)
                 
@@ -121,8 +122,8 @@ def adjust_detector_MER(fit_res,det_source_file):
     #------------------------------------------------------------------------------------
     print ('*************************************************************')
     print ('*** Detectors have been calibrated                        ***')    
-    print ('*** The name of the file with calibration information is: {0}'.format(finall_corr_file));
-    print ('*** The file is located in folder: {0}'.format(run_dir))
+    print(('*** The name of the file with calibration information is: {0}'.format(finall_corr_file)));
+    print(('*** The file is located in folder: {0}'.format(run_dir)))
     print ('*************************************************************')
     
 def mysph2cart(az,elev,r):

--- a/direct_inelastic/MERLIN/calibration/adjustdet.py
+++ b/direct_inelastic/MERLIN/calibration/adjustdet.py
@@ -122,7 +122,7 @@ def adjust_detector_MER(fit_res,det_source_file):
     #------------------------------------------------------------------------------------
     print ('*************************************************************')
     print ('*** Detectors have been calibrated                        ***')    
-    print(('*** The name of the file with calibration information is: {0}'.format(finall_corr_file)));
+    print('*** The name of the file with calibration information is: {0}'.format(finall_corr_file));
     print('*** The file is located in folder: {0}'.format(run_dir))
     print ('*************************************************************')
     

--- a/direct_inelastic/MERLIN/calibration/adjustdet.py
+++ b/direct_inelastic/MERLIN/calibration/adjustdet.py
@@ -123,7 +123,7 @@ def adjust_detector_MER(fit_res,det_source_file):
     print ('*************************************************************')
     print ('*** Detectors have been calibrated                        ***')    
     print(('*** The name of the file with calibration information is: {0}'.format(finall_corr_file)));
-    print(('*** The file is located in folder: {0}'.format(run_dir)))
+    print('*** The file is located in folder: {0}'.format(run_dir))
     print ('*************************************************************')
     
 def mysph2cart(az,elev,r):

--- a/direct_inelastic/MERLIN/calibration/create_MERInst_Files.py
+++ b/direct_inelastic/MERLIN/calibration/create_MERInst_Files.py
@@ -33,7 +33,7 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
     par_file_template = 'one2one_';
     one2onepar = par_file_template+cycle_index+'.par'
     full_one2one_par_file = create_one2onepar(run,one2onepar) 
-    print(('*** Have generated one2one par file: {0}'.format(full_one2one_par_file)));
+    print('*** Have generated one2one par file: {0}'.format(full_one2one_par_file));
     new_instrument_files_list.append(full_one2one_par_file)
     #-----------------------------------------------------------------------------------------------------------------------    
     #rings map file:
@@ -41,7 +41,7 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
     ringmap = rings_file_template + cycle_index+'.map'
 
     ring_map_full_file = create_ringmap(full_one2one_par_file,ringmap) 
-    print(('*** Have generated ring map file: {0}'.format(ring_map_full_file)));    
+    print('*** Have generated ring map file: {0}'.format(ring_map_full_file));    
     new_instrument_files_list.append(ring_map_full_file)    
     #-----------------------------------------------------------------------------------------------------------------------     
     # one2one map file:

--- a/direct_inelastic/MERLIN/calibration/create_MERInst_Files.py
+++ b/direct_inelastic/MERLIN/calibration/create_MERInst_Files.py
@@ -25,7 +25,7 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
     
     #
     print ('*************************************************************')
-    print('*** Creating MERLIN instrument files within working directory: {0}'.format(working_dir)))   
+    print('*** Creating MERLIN instrument files within working directory: {0}'.format(working_dir))   
     print ('*************************************************************')
     new_instrument_files_list = []
     #-----------------------------------------------------------------------------------------------------------------------
@@ -209,7 +209,7 @@ def check_calibration_options(cycle_end_list):
         commit_changes = True
     else:
         commit_changes = False
-        print('*** --- Can not find default repository path at {0} so no comitting to public repository will be attempted'.format(repository_path)))               
+        print('*** --- Can not find default repository path at {0} so no comitting to public repository will be attempted'.format(repository_path))
         repository_path = config['defaultsave.directory']
      # identify what cycle we are calibrating data for:
     cal_date = date.today()
@@ -227,9 +227,9 @@ def check_calibration_options(cycle_end_list):
          commit_changes = False
 
     print('*** for cycle: {0}'.format(cycle_index))  
-    print('*** Instrument files will be build in the folder {0}'.format(config['defaultsave.directory'])))                   
+    print('*** Instrument files will be build in the folder {0}'.format(config['defaultsave.directory']))
     if commit_changes:
-         print('*** and will be committed to the repository at {0}'.format(repository_path)))       
+         print('*** and will be committed to the repository at {0}'.format(repository_path))
     else:
          print('*** but will not be committed to a repository')
 

--- a/direct_inelastic/MERLIN/calibration/create_MERInst_Files.py
+++ b/direct_inelastic/MERLIN/calibration/create_MERInst_Files.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import numpy as np
 import pylab as py
@@ -24,7 +25,7 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
     
     #
     print ('*************************************************************')
-    print ('*** Creating MERLIN instrument files within working directory: {0}'.format(working_dir))    
+    print(('*** Creating MERLIN instrument files within working directory: {0}'.format(working_dir)))    
     print ('*************************************************************')
     new_instrument_files_list = []
     #-----------------------------------------------------------------------------------------------------------------------
@@ -32,7 +33,7 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
     par_file_template = 'one2one_';
     one2onepar = par_file_template+cycle_index+'.par'
     full_one2one_par_file = create_one2onepar(run,one2onepar) 
-    print ('*** Have generated one2one par file: {0}'.format(full_one2one_par_file));
+    print(('*** Have generated one2one par file: {0}'.format(full_one2one_par_file)));
     new_instrument_files_list.append(full_one2one_par_file)
     #-----------------------------------------------------------------------------------------------------------------------    
     #rings map file:
@@ -40,7 +41,7 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
     ringmap = rings_file_template + cycle_index+'.map'
 
     ring_map_full_file = create_ringmap(full_one2one_par_file,ringmap) 
-    print ('*** Have generated ring map file: {0}'.format(ring_map_full_file));    
+    print(('*** Have generated ring map file: {0}'.format(ring_map_full_file)));    
     new_instrument_files_list.append(ring_map_full_file)    
     #-----------------------------------------------------------------------------------------------------------------------     
     # one2one map file:
@@ -54,31 +55,31 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
     else:
         one2one_old_full_map = os.path.join(repository_path,one2one_old_map)        
         if  not os.path.exists(one2one_old_full_map) :
-            print  '*** --> Can not generate one2one map file: {0} as the source file is not available'.format(one2one_map)
-            print  '*** --> Copy source file: {0} into working directory: {1}'.format(one2one_old_map,working_dir)
+            print('*** --> Can not generate one2one map file: {0} as the source file is not available'.format(one2one_map))
+            print('*** --> Copy source file: {0} into working directory: {1}'.format(one2one_old_map,working_dir))
             one2one_full_map = ''
         else:
             one2one_full_map = create_one2onemap(one2one_old_full_map,one2one_map)            
     if len(one2one_full_map)>0:
-        print  '*** Have generated one2one map: {0}'.format(one2one_full_map)
+        print('*** Have generated one2one map: {0}'.format(one2one_full_map))
         new_instrument_files_list.append(one2one_full_map)        
     #----------------------------------------------------------------------------------------------------------------------- 
     print ('*************************************************************')     
-    print ('*** File generation completed  and new files are placed in folder: {0}'.format(working_dir))
+    print(('*** File generation completed  and new files are placed in folder: {0}'.format(working_dir)))
     print ('*************************************************************')    
     if commit_changes:
-        print '*** Adding new files to the repository in svn folder: {0}'.format(repository_path)
+        print('*** Adding new files to the repository in svn folder: {0}'.format(repository_path))
         # check if the files to commit exist:
         for a_file in files2commit:        
            the_file  = os.path.join(working_dir,a_file)
            if os.path.exists(the_file):
-                print '*** Preparing to commit to public repostiory file: {0}'.format(the_file)
+                print('*** Preparing to commit to public repostiory file: {0}'.format(the_file))
                 new_instrument_files_list.append(one2one_full_map)
            else:
-                print '*** --- Not committing file: {0} to public repository. It does not exist in: {1}'.format(a_file,working_dir) 
+                print('*** --- Not committing file: {0} to public repository. It does not exist in: {1}'.format(a_file,working_dir)) 
         commit_files_to_svn(repository_path,new_instrument_files_list,cycle_index)
     else:
-        print '*** Changes will not be commited as folder: {0} does not exist'.format(repository_path)        
+        print('*** Changes will not be commited as folder: {0} does not exist'.format(repository_path))        
         
 def commit_files_to_svn(svn_directory_path,fileslist,cycle_tag='current'):
      ''' routine copies the list of input files  into svn directory, 
@@ -100,16 +101,16 @@ def commit_files_to_svn(svn_directory_path,fileslist,cycle_tag='current'):
              n_added_files += 1            
              out = subprocess.check_output(['svn','add',targ],cwd = svn_directory_path,stderr=subprocess.STDOUT,shell=True)
              if len(out)>0:
-                 print out
+                 print(out)
      
      if n_added_files > 0:
-         print '*** Added {0} new files to svn script repository'.format(n_added_files)
-     print '*** Updating svn repository with {0} existing and {1} new generated MERLIN insrument files'.format(len(fileslist),n_added_files)
+         print('*** Added {0} new files to svn script repository'.format(n_added_files))
+     print('*** Updating svn repository with {0} existing and {1} new generated MERLIN insrument files'.format(len(fileslist),n_added_files))
          
      message = '-m\" Merlin autocommitted instrument files for cycle: '+cycle_tag+'\"'
      command = 'svn commit '+message+';\n exit 0;'
      out= subprocess.check_output(command ,cwd = svn_directory_path,stderr=subprocess.STDOUT,shell=True)
-     print out
+     print(out)
       
 
 # script to make one2one.par file - partially using Mantid script
@@ -208,13 +209,13 @@ def check_calibration_options(cycle_end_list):
         commit_changes = True
     else:
         commit_changes = False
-        print ('*** --- Can not find default repository path at {0} so no comitting to public repository will be attempted'.format(repository_path))                
+        print(('*** --- Can not find default repository path at {0} so no comitting to public repository will be attempted'.format(repository_path)))                
         repository_path = config['defaultsave.directory']
      # identify what cycle we are calibrating data for:
     cal_date = date.today()
     print ('*************************************************************')    
     print ('*** running MERLIN instrument files generation script')        
-    print  '*** Current date: ',cal_date.isoformat()
+    print('*** Current date: ',cal_date.isoformat())
     cycle_index = 'future'
     will_commit = 'will not be committed'
     # identify current cycle, when we are running the calibration
@@ -225,10 +226,10 @@ def check_calibration_options(cycle_end_list):
     if cycle_index == 'future':
          commit_changes = False
 
-    print '*** for cycle: {0}'.format(cycle_index)  
-    print('*** Instrument files will be build in the folder {0}'.format(config['defaultsave.directory']))                    
+    print('*** for cycle: {0}'.format(cycle_index))  
+    print(('*** Instrument files will be build in the folder {0}'.format(config['defaultsave.directory'])))                    
     if commit_changes:
-         print('*** and will be committed to the repository at {0}'.format(repository_path))        
+         print(('*** and will be committed to the repository at {0}'.format(repository_path)))        
     else:
          print('*** but will not be committed to a repository')
 
@@ -248,8 +249,8 @@ if __name__ == "__main__":
     # The script stores all its results in Manit Default save directory and 
     
      # list of the known cycles with approximate  end dates:          
-    cycle_end_list = {date(2019,03,29):'184',date(2019,07,19):'191',date(2019,10,25):'192',\
-    date(2019,12,20):'193',date(2999,01,01):'future'}
+    cycle_end_list = {date(2019,0o3,29):'184',date(2019,0o7,19):'191',date(2019,10,25):'192',\
+    date(2019,12,20):'193',date(2999,0o1,0o1):'future'}
     
     # old one2one map file used as source for one2one map file used in current cycle
     one2one_source_map = 'one2one_182.map' 

--- a/direct_inelastic/MERLIN/calibration/create_MERInst_Files.py
+++ b/direct_inelastic/MERLIN/calibration/create_MERInst_Files.py
@@ -25,7 +25,7 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
     
     #
     print ('*************************************************************')
-    print(('*** Creating MERLIN instrument files within working directory: {0}'.format(working_dir)))    
+    print('*** Creating MERLIN instrument files within working directory: {0}'.format(working_dir)))   
     print ('*************************************************************')
     new_instrument_files_list = []
     #-----------------------------------------------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ def create_MERInst_Files(run,commit_changes,repository_path,cycle_index,one2one_
         new_instrument_files_list.append(one2one_full_map)        
     #----------------------------------------------------------------------------------------------------------------------- 
     print ('*************************************************************')     
-    print(('*** File generation completed  and new files are placed in folder: {0}'.format(working_dir)))
+    print('*** File generation completed  and new files are placed in folder: {0}'.format(working_dir))
     print ('*************************************************************')    
     if commit_changes:
         print('*** Adding new files to the repository in svn folder: {0}'.format(repository_path))
@@ -209,7 +209,7 @@ def check_calibration_options(cycle_end_list):
         commit_changes = True
     else:
         commit_changes = False
-        print(('*** --- Can not find default repository path at {0} so no comitting to public repository will be attempted'.format(repository_path)))                
+        print('*** --- Can not find default repository path at {0} so no comitting to public repository will be attempted'.format(repository_path)))               
         repository_path = config['defaultsave.directory']
      # identify what cycle we are calibrating data for:
     cal_date = date.today()
@@ -227,9 +227,9 @@ def check_calibration_options(cycle_end_list):
          commit_changes = False
 
     print('*** for cycle: {0}'.format(cycle_index))  
-    print(('*** Instrument files will be build in the folder {0}'.format(config['defaultsave.directory'])))                    
+    print('*** Instrument files will be build in the folder {0}'.format(config['defaultsave.directory'])))                   
     if commit_changes:
-         print(('*** and will be committed to the repository at {0}'.format(repository_path)))        
+         print('*** and will be committed to the repository at {0}'.format(repository_path)))       
     else:
          print('*** but will not be committed to a repository')
 

--- a/direct_inelastic/MERLIN/calibration/tubecalib.py
+++ b/direct_inelastic/MERLIN/calibration/tubecalib.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import scipy
 from scipy.optimize import fmin
@@ -61,9 +62,9 @@ def tube_calibrate_MER(run,tmin,tmax,*args):
         tubestart = tube
         tubeend = tube
         cal_info = 'door-{0}_pack-{1}_tube-{2}'.format(bank,pack,tube)
-        print doorstart
-        print packstart
-        print tubestart
+        print(doorstart)
+        print(packstart)
+        print(tubestart)
 
     run_dir =  config['defaultsave.directory']
     targ_file_name =  'calibratioon_res_{0}.csv'.format(cal_info)
@@ -76,7 +77,7 @@ def tube_calibrate_MER(run,tmin,tmax,*args):
         for pack in range(packstart[np.array(bank)-1],packend[np.array(bank)-1]+1):
             for tube in range(tubestart,tubeend+1):
                 tube_id = int(str(bank)+str(pack)+str(tube))
-                print tube_id
+                print(tube_id)
                 myindex = np.nonzero(det_tubes==tube_id)
                 spec_tube = np.array(spec_num)[[myindex[0]]]
                 spec_min = int(min(spec_tube))
@@ -93,15 +94,15 @@ def tube_calibrate_MER(run,tmin,tmax,*args):
                 if max(yval)!=0:
                     myout = myfit_data(bank,pack,tube,yval,mylen)
                 if myout is not None:
-                    print tube_id,myout[0],myout[1],myout[2],myout[3],myout[4],myout[5],myout[6]
+                    print(tube_id,myout[0],myout[1],myout[2],myout[3],myout[4],myout[5],myout[6])
                     fid.write('{0:3.0f}, {1:0.2f}, {2:0.2f}, {3:0.2f}, {4:0.2f}, {5:0.2f}, {6:0.2f}, {7:0.2f}\n'.format(tube_id,myout[0],myout[1],myout[2],myout[3],myout[4],myout[5],myout[6]))
                 else:
                     plt.show(1)
                     raise RuntimeError('Could not fit')
     fid.close()
     print('***********************************************')
-    print('*** Calibration info is written in file: {0}'.format(targ_file_name));
-    print('*** Located in folder: {0}'.format(run_dir));    
+    print(('*** Calibration info is written in file: {0}'.format(targ_file_name)));
+    print(('*** Located in folder: {0}'.format(run_dir)));    
     print('***********************************************')    
     
     
@@ -110,7 +111,7 @@ def tube_calibrate_MER(run,tmin,tmax,*args):
  
 def myfit_data(bank,pack,tube,Intensity,mylen):
     error = np.sqrt(Intensity)
-    position = range(1,513)
+    position = list(range(1,513))
     left_end = 0
     middle = 0
     right_end = 0
@@ -182,7 +183,7 @@ def myfit_data(bank,pack,tube,Intensity,mylen):
         return
     
     left_end = p[1]
-    print left_end
+    print(left_end)
     if mylen==3:    
         myx = np.arange(min(pos),max(pos),0.5)
         myy = endf(p,myx)
@@ -247,7 +248,7 @@ def myfit_data(bank,pack,tube,Intensity,mylen):
         return
 
     right_end = p[1]
-    print right_end
+    print(right_end)
     if mylen==3:
         myx = np.arange(min(pos),max(pos),0.5)
         myy = endf(p,myx)
@@ -312,7 +313,7 @@ def myfit_data(bank,pack,tube,Intensity,mylen):
             plt.show()
             plt.draw()
         stripe1 = p[1]
-        print stripe1
+        print(stripe1)
         stripes.append(stripe1)
 
     if np.logical_and(bank==3,pack==1): 

--- a/direct_inelastic/MERLIN/calibration/tubecalib.py
+++ b/direct_inelastic/MERLIN/calibration/tubecalib.py
@@ -101,8 +101,8 @@ def tube_calibrate_MER(run,tmin,tmax,*args):
                     raise RuntimeError('Could not fit')
     fid.close()
     print('***********************************************')
-    print(('*** Calibration info is written in file: {0}'.format(targ_file_name)));
-    print(('*** Located in folder: {0}'.format(run_dir)));    
+    print('*** Calibration info is written in file: {0}'.format(targ_file_name));
+    print('*** Located in folder: {0}'.format(run_dir));    
     print('***********************************************')    
     
     

--- a/direct_inelastic/MERLIN/example_pychop_script_merlin.py
+++ b/direct_inelastic/MERLIN/example_pychop_script_merlin.py
@@ -1,4 +1,5 @@
 #Example script for using PyChop
+from __future__ import print_function
 
 #All examples are for MAPS, but the same routines can be used for MARI on MERLIN
 

--- a/direct_inelastic/MERLIN/iliad_merlin_eventmode.py
+++ b/direct_inelastic/MERLIN/iliad_merlin_eventmode.py
@@ -1,6 +1,7 @@
 """      
 MERLIN TRANSIENT REDUCTION SCRIPT MARCH 2014;
 """
+from __future__ import print_function
 from qtiGenie import *
 #from PySlice2 import *
 
@@ -87,7 +88,7 @@ if loadFreshWB:
 for sample_run in run_no:
      
     fname='MER00'+str(sample_run)+'.nxs'
-    print ' processing file ', fname
+    print(' processing file ', fname)
     #w1 = dgreduce.getReducer().load_data(run,'w1')
     Load(Filename=fname,OutputWorkspace='w1',LoadMonitors='1');
     
@@ -100,8 +101,8 @@ for sample_run in run_no:
      # this section finds all the transmitted incident energies if you have not provided them
     if len(ei) == 0:
         ei = find_chopper_peaks('w1_monitors');
-        print ei
-    print 'Energies transmitted are:'
+        print(ei)
+    print('Energies transmitted are:')
     print (ei)
 
     RenameWorkspace(InputWorkspace = 'w1',OutputWorkspace='w1_storage');
@@ -109,9 +110,9 @@ for sample_run in run_no:
                     
     #now loop around all energies for the run
     for ind,energy in enumerate(ei):
-        print "Reducing around energy: {0}".format(float(energy))
+        print("Reducing around energy: {0}".format(float(energy)))
         (energybin,tbin,t_elastic) = find_binning_range(energy,ebin);
-        print " Rebinning will be performed in the range: ",energybin
+        print(" Rebinning will be performed in the range: ",energybin)
         
         # if we calculate more then one energy, initial workspace will be used more then once. Is this enough for that?    
         #Rebin(InputWorkspace='w1',OutputWorkspace='w1reb',Params=tbin,PreserveEvents='1')                        

--- a/direct_inelastic/MERLIN/mantid_iliad_abs_August2014.py
+++ b/direct_inelastic/MERLIN/mantid_iliad_abs_August2014.py
@@ -1,6 +1,7 @@
 """
 The sample script for MERLIN absolute units reduction. Copied from LET system tests. 
 """
+from __future__ import print_function
 from qtiGenie import *
 iliad_setup('MER')
 
@@ -57,10 +58,10 @@ if present_run !=wb:  #only load whitebeam if not already there
  
 ######################################################################
 present_run=-1
-for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
+for irun in range(0,len(run_no),num_files2sum):    #loop around runs
        run = run_no[irun];
        fname='MER0000'+str(run)+'.nxs'
-       print ' processing file ', fname
+       print(' processing file ', fname)
        #if 'w1' in mtd:  # Uncomment this to save time and not to load existing workspace twice
        #     m=mtd['w1']
        #     present_run= m.getRunNumber()
@@ -69,13 +70,13 @@ for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
        if  present_run != run:
             w1, w1_monitors=Load(Filename=fname,LoadMonitors='1',MonitorsAsEvents='0')  
             w1_mon=RenameWorkspace(w1_monitors)
-            for ns in xrange(num_files2sum-1):
-                print " Adding run N {0} to run N {1}".format(run_no[irun+ns+1],run_no[irun]),
+            for ns in range(num_files2sum-1):
+                print(" Adding run N {0} to run N {1}".format(run_no[irun+ns+1],run_no[irun]), end=' ')
                 run = run_no[irun+ns+1]
                 ws,ws_monitors= Load(Filename='MER0000'+str(run)+'.nxs',SingleBankPixelsOnly='0',LoadMonitors='1',MonitorsAsEvents='0')
                 w1 += ws
                 w1_mon += ws_monitors
-                print "got {0} events".format(w1.getNumberEvents())
+                print("got {0} events".format(w1.getNumberEvents()))
                 AddSampleLog(Workspace='w1',LogName='run_number_'+str(run),LogText=str(run),LogType='Number') #only have to do this as run_number is passed to workspace for event files       
               
        if remove_background:
@@ -85,7 +86,7 @@ for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
         # this section finds all the transmitted incident energies if you have not provided them
        if len(ei) == 0:  #-- not tested here -- should be unit test for that. 
             ei = find_chopper_peaks('w1_monitors');       
-       print 'Energies transmitted are:',
+       print('Energies transmitted are:', end=' ')
        print (ei)
 
        RenameWorkspace(InputWorkspace = 'w1',OutputWorkspace='w1_storage');
@@ -94,9 +95,9 @@ for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
        #now loop around all energies for the run
        result =[];
        for ind,energy in enumerate(ei):
-                print float(energy)
+                print(float(energy))
                 (energybin,tbin,t_elastic) = find_binning_range(energy,ebin);
-                print " Rebinning will be performed in the range: ",energybin
+                print(" Rebinning will be performed in the range: ",energybin)
                 # if we calculate more then one energy, initial workspace will be used more then once
                 if ind <len(ei)-1:
                     CloneWorkspace(InputWorkspace = 'w1_storage',OutputWorkspace='w1')
@@ -136,5 +137,5 @@ for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
                 ws_name = 'MER{0}_ei{1:2.1f}mev'.format(run,energy);
                 #RenameWorkspace(InputWorkspace=out,OutputWorkspace=ws_name);
                 fileName=ws_name+'_Rings_125abs.nxspe';
-                print 'Saving results into file {0}'.format(fileName)
+                print('Saving results into file {0}'.format(fileName))
                 SaveNXSPE(InputWorkspace=out,Filename=fileName)		

--- a/direct_inelastic/MERLIN/mantid_iliad_abs_sample.py
+++ b/direct_inelastic/MERLIN/mantid_iliad_abs_sample.py
@@ -3,6 +3,7 @@ The sample script for MERLIN absolute units reduction.
 Should be used for non_abs units too by setting MonoVanRun number to None
 File copied from current (31/07.2014) Mantid System tests for LET and modified with MERLIN settings
 """
+from __future__ import print_function
 from qtiGenie import *
 import datetime
 iliad_setup('merlin')
@@ -66,10 +67,10 @@ if present_run !=wb:  #only load whitebeam if not already there
 ######################################################################
 start = time.clock()
 present_run=-1
-for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
+for irun in range(0,len(run_no),num_files2sum):    #loop around runs
        run = run_no[irun];
        fname='MER0000'+str(run)+'.nxs'
-       print ' processing file ', fname
+       print(' processing file ', fname)
        #if 'w1' in mtd:  # Uncomment this to save time and not to load existing workspace twice
        #     m=mtd['w1']
        #     present_run= m.getRunNumber()
@@ -78,13 +79,13 @@ for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
        if  present_run != run:
             w1, w1_monitors=Load(Filename=fname,LoadMonitors='1',MonitorsAsEvents='0')  
             w1_mon=RenameWorkspace(w1_monitors)
-            for ns in xrange(num_files2sum-1):
-                print " Adding run N {0} to run N {1}".format(run_no[irun+ns+1],run_no[irun]),
+            for ns in range(num_files2sum-1):
+                print(" Adding run N {0} to run N {1}".format(run_no[irun+ns+1],run_no[irun]), end=' ')
                 run = run_no[irun+ns+1]
                 ws,ws_monitors= Load(Filename='MER0000'+str(run)+'.nxs',SingleBankPixelsOnly='0',LoadMonitors='1',MonitorsAsEvents='0')
                 w1 += ws
                 w1_mon += ws_monitors
-                print "got {0} events".format(w1.getNumberEvents())
+                print("got {0} events".format(w1.getNumberEvents()))
                 AddSampleLog(Workspace='w1',LogName='run_number_'+str(run),LogText=str(run),LogType='Number') #only have to do this as run_number is passed to workspace for event files       
        
        
@@ -95,7 +96,7 @@ for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
         # this section finds all the transmitted incident energies if you have not provided them
        if len(ei) == 0:  #-- not tested here -- should be unit test for that. 
             ei = find_chopper_peaks('w1_monitors');       
-       print 'Energies transmitted are:',
+       print('Energies transmitted are:', end=' ')
        print (ei)
 
        RenameWorkspace(InputWorkspace = 'w1',OutputWorkspace='w1_storage');
@@ -104,9 +105,9 @@ for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
        #now loop around all energies for the run
        result =[];
        for ind,energy in enumerate(ei):
-                print float(energy)
+                print(float(energy))
                 (energybin,tbin,t_elastic) = find_binning_range(energy,ebin);
-                print " Rebinning will be performed in the range: ",energybin
+                print(" Rebinning will be performed in the range: ",energybin)
                 # if we calculate more then one energy, initial workspace will be used more then once
                 if ind <len(ei)-1:
                     CloneWorkspace(InputWorkspace = 'w1_storage',OutputWorkspace='w1')
@@ -141,8 +142,8 @@ for irun in xrange(0,len(run_no),num_files2sum):    #loop around runs
                 ws_name = 'MER{0}_ei{1:3.1f}mev'.format(run,energy);
                 #RenameWorkspace(InputWorkspace=out,OutputWorkspace=ws_name);
                 fileName=ws_name+'.nxspe';
-                print 'Saving results into file {0}'.format(fileName)
+                print('Saving results into file {0}'.format(fileName))
                 SaveNXSPE(InputWorkspace=out,Filename=fileName)
 ##############################
 elapsed = (time.clock() - start)
-print "Time to run the whole reduction",(elapsed)
+print("Time to run the whole reduction",(elapsed))

--- a/direct_inelastic/MERLIN/template_merlin.py
+++ b/direct_inelastic/MERLIN/template_merlin.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid import config
 from iliad_merlin import *
 import time
@@ -52,7 +53,7 @@ bg_range=[18000,19000]
 #but it is easier to see what is going on here)
 
 #Run number is range start, end+1 (due to annoying python syntax)
-runno=range(24742,25515)
+runno=list(range(24742,25515))
 ei=[120,43,22]
 
 for i in range(len(runno)):
@@ -72,7 +73,7 @@ for i in range(len(runno)):
 				iliad_merlin_crystal(runno[i],ei,wbvan,rebin_pars,monovan,sam_mass,sam_rmm,bg_range)
 				latest_run=latest_run+1
 			except:
-				print 'Skipped run numr '+str(latest_run)
+				print('Skipped run numr '+str(latest_run))
 				latest_run=latest_run+1
 		else:
 			Pause(600)

--- a/direct_inelastic/SNS/MaskBTP.py
+++ b/direct_inelastic/SNS/MaskBTP.py
@@ -1,6 +1,7 @@
 """
 Mask banks, tubes, and pixels on ARCS/SEQUOIA/CNCS/HYSPEC 
 """
+from __future__ import print_function
 from numpy import arange
 from mantid import *
 from mantid.simpleapi import *
@@ -58,7 +59,7 @@ def MaskBTP(**kwargs):
     try:
         instrumentList.index(instrument)
     except:
-        print "Instrument not found"
+        print("Instrument not found")
         return detlist
     if (workspace==None):
         path=config["instrumentDefinition.directory"]

--- a/direct_inelastic/SNS/Tdep50meV.py
+++ b/direct_inelastic/SNS/Tdep50meV.py
@@ -1,11 +1,12 @@
 """
 Plot temperature dependence for data in a set of runs
 """
+from __future__ import print_function
 from numpy import *
 from string import *
 
 IPTSpath='/SNS/SEQ/IPTS-6225'
-runsTup=range(32752,32846)
+runsTup=list(range(32752,32846))
 
 #filename=IPTSpath+'/data/SEQ_32846_event.nxs'
 #wm=LoadNexusMonitors(filename)
@@ -48,16 +49,16 @@ for r in runsTup:
 	signal2=s2.readY(0)[0]
 
 	temp=(w1.getRun()['SampleTemp']).getStatistics().mean
-	print temp,signal1,Imax1,signal2,Imax2
+	print(temp,signal1,Imax1,signal2,Imax2)
 	allTemps.append(temp)
 	allIntegratedSignal1.append(signal1)
 	allPeakSignal1.append(Imax1)
 	allIntegratedSignal2.append(signal2)
 	allPeakSignal2.append(Imax2)
 	
-z=zip(allTemps,allPeakSignal1,allIntegratedSignal1,allPeakSignal2,allIntegratedSignal2)
+z=list(zip(allTemps,allPeakSignal1,allIntegratedSignal1,allPeakSignal2,allIntegratedSignal2))
 z.sort()
-allTemps,allPeakSignal1,allIntegratedSignal1,allPeakSignal2,allIntegratedSignal2=zip(*z)
+allTemps,allPeakSignal1,allIntegratedSignal1,allPeakSignal2,allIntegratedSignal2=list(zip(*z))
 
 Int_1p5_0p0=CreateWorkspace(allTemps,allIntegratedSignal1,sqrt(allIntegratedSignal1),1,YUnitLabel='Counts/muAh')
 Peak_1p5_0p0=CreateWorkspace(allTemps,allPeakSignal1,sqrt(allPeakSignal1),1,YUnitLabel='Counts/muAh')

--- a/direct_inelastic/SNS/WB_Tdep.py
+++ b/direct_inelastic/SNS/WB_Tdep.py
@@ -1,12 +1,13 @@
 """
 Temperature dependence of scattering intensity between Qmin,Qmax. Detectors are groupped 16x4, the groups belonging to data/background are selected below
 """
+from __future__ import print_function
 
 from numpy import *
 from string import *
 
 IPTSpath='/SNS/SEQ/IPTS-6225'
-runsup=range(32298,32357)
+runsup=list(range(32298,32357))
 runsdown=arange(32357,32411)
 runsdown=append(runsdown,arange(32412,32513))
 
@@ -41,16 +42,16 @@ for r in runsup:
 	err=sqrt(signal)/len(dataGroups)
 	signal=signal/len(dataGroups)
 	temp=(wg.getRun()['SampleTemp']).getStatistics().mean
-	print temp,signal,err,bkg,errbkg
+	print(temp,signal,err,bkg,errbkg)
 	alltemps.append(temp)
 	allsignal.append(signal)
 	allerror.append(err)
 	allbkg.append(bkg)
 	allbkgerr.append(errbkg)
 	
-z=zip(alltemps,allsignal,allerror,allbkg,allbkgerr)
+z=list(zip(alltemps,allsignal,allerror,allbkg,allbkgerr))
 z.sort()
-alltemps,allsignal,allerror,allbkg,allbkgerr=zip(*z)
+alltemps,allsignal,allerror,allbkg,allbkgerr=list(zip(*z))
 
 Intup=CreateWorkspace(alltemps,allsignal,allerror,1,YUnitLabel='Counts/muAh')
 BGup=CreateWorkspace(alltemps,allbkg,allbkgerr,1,YUnitLabel='Counts/muAh')
@@ -81,16 +82,16 @@ for r in runsdown:
 	err=sqrt(signal)/len(dataGroups)
 	signal=signal/len(dataGroups)
 	temp=(wg.getRun()['SampleTemp']).getStatistics().mean
-	print temp,signal,err,bkg,errbkg
+	print(temp,signal,err,bkg,errbkg)
 	alltemps.append(temp)
 	allsignal.append(signal)
 	allerror.append(err)
 	allbkg.append(bkg)
 	allbkgerr.append(errbkg)
 	
-z=zip(alltemps,allsignal,allerror,allbkg,allbkgerr)
+z=list(zip(alltemps,allsignal,allerror,allbkg,allbkgerr))
 z.sort()
-alltemps,allsignal,allerror,allbkg,allbkgerr=zip(*z)
+alltemps,allsignal,allerror,allbkg,allbkgerr=list(zip(*z))
 
 Intdown=CreateWorkspace(alltemps,allsignal,allerror,1,YUnitLabel='Counts/muAh')
 BGdown=CreateWorkspace(alltemps,allbkg,allbkgerr,1,YUnitLabel='Counts/muAh')

--- a/direct_inelastic/SNS/fixDASLogs.py
+++ b/direct_inelastic/SNS/fixDASLogs.py
@@ -4,7 +4,7 @@ function to change initial time for logs to coincide with the first proton pulse
 def fixlogs(WS):
 	run=mtd[WS].getRun()
 	PC =  run['proton_charge'].firstTime()
-	for log_name in run.keys():
+	for log_name in list(run.keys()):
 		if log_name not in ['duration','proton_charge','start_time','run_title','run_start','run_number','gd_prtn_chrg','end_time']:
 			try:
 				P =  run[log_name].firstTime()

--- a/direct_inelastic/SNS/generate_string_base.py
+++ b/direct_inelastic/SNS/generate_string_base.py
@@ -1,6 +1,7 @@
 """
 Generate a list of runs where some log values obey certain criteria. Input can be from log.py 
 """
+from __future__ import print_function
 from string import *
 from numpy import *
 f=open('/SNS/SEQ/IPTS-6179/shared/2K_50meV_complete/complete_log_2K_50meV.txt','r')
@@ -18,4 +19,4 @@ for i in arange(listsize):
 runlist=[]
 for i in arange(-90,39,1):
 	runlist.append(list(runs[where((angs==i))]))#(temps>70) &
-print runlist
+print(runlist)

--- a/direct_inelastic/SNS/groupNxspe.py
+++ b/direct_inelastic/SNS/groupNxspe.py
@@ -8,12 +8,12 @@ from numpy import *
 r_0 = [33008,33009]  
 r_180 = [33383,33384]
 # -0 < Omega CCR < -90
-r1 = range(33012,33193)
-r2 = range(33385,33566)
+r1 = list(range(33012,33193))
+r2 = list(range(33385,33566))
 # -30 < Omega CCR < -60
-r3 = range(33573,33635)
+r3 = list(range(33573,33635))
 # -90 < Omega CCR < -180
-r4 = range(33196,33377)
+r4 = list(range(33196,33377))
 All_runs = r1+r2+r3+r4 + r_0 + r_180
 
 # 50 meV

--- a/direct_inelastic/SNS/log.py
+++ b/direct_inelastic/SNS/log.py
@@ -1,12 +1,13 @@
 """
 Quicly check logs for multiple runs
 """
+from __future__ import print_function
 from numpy import *
 from string import *
 runs=arange(22579,23388,1)
 prefix="/SNS/SEQ/IPTS-6179/data/SEQ_"
 suffix="_event.nxs"
-print "  Run   Temp       Angle    PC 	HIST	Energy"
+print("  Run   Temp       Angle    PC 	HIST	Energy")
 for r in runs:
 	CreateSingleValuedWorkspace(OutputWorkspace="w",DataValue="0")
 	LoadNexusLogs(Workspace="w",Filename=prefix+str(r)+suffix,OverwriteLogs=True)
@@ -18,6 +19,6 @@ for r in runs:
 	energy=array(runinfo["EnergyRequest"].value).mean()
 	LoadNexusMonitors(OutputWorkspace='w1',Filename=prefix+str(r)+suffix)
 	nhistmon=mtd['w1'].getNumberHistograms()
-	print r,temp,angle,pc,nhistmon,energy
+	print(r,temp,angle,pc,nhistmon,energy)
 	DeleteWorkspace('w')
 	DeleteWorkspace('w1')

--- a/direct_inelastic/SNS/new_scan.py
+++ b/direct_inelastic/SNS/new_scan.py
@@ -1,6 +1,7 @@
 """
 Updated version of rocking curve scan.py, using FilterEvents
 """
+from __future__ import print_function
 import numpy as np
 ang_name='CCR12Rot'
 ang_deriv='CCR12RotDeriv'
@@ -9,7 +10,7 @@ t_off=0.0
 step=0.2
 ang_bins=np.arange(160-step/2,169+step/1.5,step)
 
-runs=range(12956,12966+1)			#list of runs that have the same condition
+runs=list(range(12956,12966+1))			#list of runs that have the same condition
 datadir="/SNS/ARCS/IPTS-4041/0/"		#Data directory	
 run_num = str(runs[0])
 filename=datadir+run_num+"/NeXus/ARCS_"+run_num+"_event.nxs"
@@ -28,7 +29,7 @@ LoadNexus(Filename=r'/SNS/users/vua/Mantid/Angle_binning_reduction/mask5_exclude
 MaskDetectors("w",MaskedWorkspace="MaskWorkspace")
 w=mtd["w"]
 rate = np.absolute(np.array(w.getRun()[ang_deriv].value)).mean()
-print "Rate(deg/sec)):",rate
+print("Rate(deg/sec)):",rate)
 ang_list_plus=[]
 ang_list_minus=[]
 int_plus=[]
@@ -89,5 +90,5 @@ yp=np.array(int_plus)
 ym=np.array(int_minus)
 cp=(xp*yp).sum()/yp.sum()
 cm=(xm*ym).sum()/ym.sum()
-print "Center-of-Mass - Plus:",cp,"Minus:",cm,"Difference:",cp-cm
-print "Estimated time offset:", t_off + (cp-cm)/rate/2
+print("Center-of-Mass - Plus:",cp,"Minus:",cm,"Difference:",cp-cm)
+print("Estimated time offset:", t_off + (cp-cm)/rate/2)

--- a/direct_inelastic/SNS/print_u_v_vector.py
+++ b/direct_inelastic/SNS/print_u_v_vector.py
@@ -1,6 +1,7 @@
 """
 print u and v vectors for mslice/horace. Use in conjunction with make_d_spacing.py
 """
+from __future__ import print_function
 import numpy as np
 wksname='SingleCrystalPeakTable'
 a=3.78
@@ -13,5 +14,5 @@ CalculateUMatrix(PeaksWorkspace=wksname,a=a,b=b,c=c,alpha=alpha,beta=beta,gamma=
 h=mtd[wksname]
 uV=h.sample().getOrientedLattice().getuVector()
 vV=h.sample().getOrientedLattice().getvVector()
-print 'u=%s' %(np.array([uV.X(),uV.Y(),uV.Z()])/uV.norm())
-print 'v=%s'  %(np.array([vV.X(),vV.Y(),vV.Z()])/vV.norm())
+print('u=%s' %(np.array([uV.X(),uV.Y(),uV.Z()])/uV.norm()))
+print('v=%s'  %(np.array([vV.X(),vV.Y(),vV.Z()])/vV.norm()))

--- a/direct_inelastic/SNS/reduce_from_autoreduce_script.py
+++ b/direct_inelastic/SNS/reduce_from_autoreduce_script.py
@@ -2,6 +2,7 @@
 Reduction including generation of an experiment log 
 """
 #!/usr/bin/env python
+from __future__ import print_function
 
 import sys,os
 sys.path.append("/opt/Mantid/bin")
@@ -134,7 +135,7 @@ def autoloader(filename,outdir):
         LoadEventNexus(Filename=filename,OutputWorkspace="__IWS") #Load an event Nexus file
         #Fix that all time series log values start at the same time as the proton_charge
         r=mtd['__IWS'].getRun()
-        for x in r.keys():
+        for x in list(r.keys()):
         	if x not in ['duration','proton_charge','start_time','run_title','run_start','run_number','gd_prtn_chrg','end_time']:
         		try:
         			ShiftTime('__IWS',x)
@@ -225,10 +226,10 @@ def ShiftTime(WName,lg_name):
 if __name__ == "__main__":
     #check number of arguments
     if (len(sys.argv) != 3): 
-        print "autoreduction code requires a filename and an output directory"
+        print("autoreduction code requires a filename and an output directory")
         sys.exit()
     if not(os.path.isfile(sys.argv[1])):
-        print "data file ", sys.argv[1], " not found"
+        print("data file ", sys.argv[1], " not found")
         sys.exit()
     else:
         filename = sys.argv[1]

--- a/direct_inelastic/SNS/reduce_mult_T.py
+++ b/direct_inelastic/SNS/reduce_mult_T.py
@@ -89,7 +89,7 @@ OWSBN='E_500_ev_'
 FilterEvents(InputWorkspace='E_500',OutputWorkspaceBaseName=OWSBN,SplittersInformationWorkspace='Sp_Info',InputSplittersWorkspace='split_ws')
 h_Sp_Info=mtd['Sp_Info']
 Sp_index=np.array(h_Sp_Info.column(0))-1
-ky_lst=mantid.keys()
+ky_lst=list(mantid.keys())
 for idx in Sp_index[1:]:
    WS_name=OWSBN+'_'+str(idx)
    skip_flag=False

--- a/direct_inelastic/SNS/reducenoguess.py
+++ b/direct_inelastic/SNS/reducenoguess.py
@@ -2,6 +2,7 @@
 Simplified version of reduction using DGSReduction algorithm
 """
 #!/usr/bin/env python
+from __future__ import print_function
 
 import os
 import sys
@@ -44,7 +45,7 @@ for irun in runs:
 	Ei=alg[0]
 	erange=str(-0.2*Ei)+','+str(0.005*Ei)+','+str(0.95*Ei)
 	#change log times
-	for x in w.getRun().keys():
+	for x in list(w.getRun().keys()):
 		if x not in ['duration','proton_charge','start_time','run_title','run_start','run_number','gd_prtn_chrg','end_time']:
 			try:
 				ShiftTime('w',x)
@@ -68,7 +69,7 @@ for irun in runs:
 	r=mtd['reduced']
 	psi=r.getRun()['CCR16Rot'].getStatistics().mean
 	outfilename=IPTS_directory+'shared/Rotreduced/SEQ_'+str(irun)+'.nxspe'
-	print irun,psi
+	print(irun,psi)
 	irun=irun+1
 	SaveNXSPE(r,outfilename,r.getRun()['Ei'].value,psi,'1')
 

--- a/direct_inelastic/SNS/scan.py
+++ b/direct_inelastic/SNS/scan.py
@@ -1,6 +1,7 @@
 """
 Rocking scan (+ and - directions)
 """
+from __future__ import print_function
 import numpy as np
 
 ang_name='CCR12Rot'
@@ -25,7 +26,7 @@ e_minus=[]
 
 
 for i in np.arange(minpsi,maxpsi-step,step):
-	print i
+	print(i)
 	FilterByLogValue(InputWorkspace="w",OutputWorkspace="wi",LogName=ang_name,MinimumValue=i,MaximumValue=i+step)
 	if (mtd["wi"].getNumberEvents()>1):
 		FilterByLogValue(InputWorkspace="wi",OutputWorkspace="wip",LogName=ang_deriv,MinimumValue=0.,MaximumValue=1e100)

--- a/direct_inelastic/SNS/testtib.py
+++ b/direct_inelastic/SNS/testtib.py
@@ -3,6 +3,7 @@ Test if time independent background range is OK
 Note - runs in MantidPlot
 Note - uses pdftk to concatenate pdf files
 """
+from __future__ import print_function
 from numpy import *
 from string import *
 import os
@@ -35,47 +36,47 @@ def SpurionPromptPulse2(Ei, msd = 1800.0, tail_length_us = 3000.0, talk = False)
     #print t_focEle_us,pre_lead_us,frame_start_us,MinTIB_us,slop_frac
     if (t_focEle_us < pre_lead_us) and (t_focEle_us-frame_start_us > MinTIB_us * (slop_frac + 1.0)):
         if talk:
-            print 'choosing TIB just before focus element-1'
+            print('choosing TIB just before focus element-1')
         TIB_high_us = t_focEle_us - MinTIB_us * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us
     elif (frame_start_us>pre_tail_us) and (t_focEle_us-frame_start_us > MinTIB_us * (slop_frac + 1.0)):
         if talk:
-            print 'choosing TIB just before focus element-2'
+            print('choosing TIB just before focus element-2')
         TIB_high_us = t_focEle_us - MinTIB_us * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us
     elif t_focEle_us-pre_tail_us > MinTIB_us * (slop_frac + 1.0) and (t_focEle_us-frame_start_us > MinTIB_us * (slop_frac + 1.0)):
         if talk:
-            print 'choosing TIB just before focus element-3'
+            print('choosing TIB just before focus element-3')
         TIB_high_us = t_focEle_us - MinTIB_us * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us
     elif t_samp_us-pre_tail_us > MinTIB_us * (slop_frac + 1.0) and (t_samp_us-frame_start_us > MinTIB_us * (slop_frac + 1.0)):
         if talk:
-            print 'choosing TIB just before sample-1'
+            print('choosing TIB just before sample-1')
         TIB_high_us = t_samp_us - MinTIB_us * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us
     elif t_samp_us-pre_tail_us > MinTIB_us / 1.5 * (slop_frac + 1.0) and (t_samp_us-frame_start_us > MinTIB_us * (slop_frac + 1.0)):
         if talk:
-            print 'choosing TIB just before sample-2'
+            print('choosing TIB just before sample-2')
         TIB_high_us = t_samp_us - MinTIB_us / 1.5 * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us / 1.5
     elif t_samp_us-pre_tail_us > MinTIB_us / 2.0 * (slop_frac + 1.0) and (t_samp_us-frame_start_us > MinTIB_us * (slop_frac + 1.0)):
         if talk:
-            print 'choosing TIB just before sample-3'
+            print('choosing TIB just before sample-3')
         TIB_high_us = t_samp_us - MinTIB_us / 2.0 * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us / 2.0
     elif (pre_lead_us - frame_start_us > MinTIB_us * (slop_frac + 1.0)) and (t_focEle_us > pre_lead_us):
         if talk:
-            print 'choosing TIB just before leading edge before elastic-1'
+            print('choosing TIB just before leading edge before elastic-1')
         TIB_high_us = pre_lead_us - MinTIB_us * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us
     elif (pre_lead_us - frame_start_us > MinTIB_us / 1.5 * (slop_frac + 1.0)) and (t_focEle_us > pre_lead_us):
         if talk:
-            print 'choosing TIB just before leading edge before elastic-2'
+            print('choosing TIB just before leading edge before elastic-2')
         TIB_high_us = pre_lead_us - MinTIB_us / 1.5 * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us / 1.5
     elif (pre_lead_us - frame_start_us > MinTIB_us / 2.0 * (slop_frac + 1.0)) and (t_focEle_us > pre_lead_us):
         if talk:
-            print 'choosing TIB just before leading edge before elastic-3'
+            print('choosing TIB just before leading edge before elastic-3')
         TIB_high_us = pre_lead_us - MinTIB_us / 2.0 * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us / 2.0
 #    elif (pre_tail_us > frame_start_us) and (t_focEle_us - pre_tail_us > MinTIB_us * (slop_frac + 1.0)):
@@ -86,23 +87,23 @@ def SpurionPromptPulse2(Ei, msd = 1800.0, tail_length_us = 3000.0, talk = False)
 #        TIB_high_us = TIB_low_us + MinTIB_us
     elif post_lead_us > frame_end_us:
         if talk:
-            print 'choosing TIB at end of frame'
+            print('choosing TIB at end of frame')
         TIB_high_us = frame_end_us - MinTIB_us * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us
     elif post_lead_us - t_det_us > MinTIB_us * (slop_frac + 1.0):
         if talk:
-            print 'choosing TIB between elastic peak and later prompt pulse leading edge'
+            print('choosing TIB between elastic peak and later prompt pulse leading edge')
         TIB_high_us = post_lead_us - MinTIB_us * slop_frac / 2.0
         TIB_low_us = TIB_high_us - MinTIB_us
     else:
         if talk:
-            print 'I cannot find a good TIB range'
+            print('I cannot find a good TIB range')
         TIB_low_us = 0.0
         TIB_high_us = 0.0
     return [TIB_low_us, TIB_high_us]
 
-runs=range(12312,12348)
-runs.extend(range(12408,12434))
+runs=list(range(12312,12348))
+runs.extend(list(range(12408,12434)))
 
 od='/SNS/users/3y9/Desktop/test/'
 com='pdftk '

--- a/direct_inelastic/SNS/tof_plot_make.py
+++ b/direct_inelastic/SNS/tof_plot_make.py
@@ -4,7 +4,7 @@ Make some plots using matplotlib
 from mantid.simpleapi import*
 outdir='/SNS/SEQ/IPTS-7672/shared/19g/tof_figs/'
 indir='/SNS/SEQ/IPTS-7672/data/'
-runs=range(33012,33193)
+runs=list(range(33012,33193))
 
 def plot_sum(x,y,err,titlestr='',xstr='',ystr=''):
 	h_f=figure()

--- a/indirect_inelastic/ISIS/Bayes/Quasi/IndirectBayes.py
+++ b/indirect_inelastic/ISIS/Bayes/Quasi/IndirectBayes.py
@@ -1,4 +1,5 @@
 #pylint: disable=invalid-name,too-many-arguments,too-many-locals
+from __future__ import print_function
 
 """
 Bayes routines
@@ -220,7 +221,7 @@ def read_ql_file(file_name, nl):
 
     #iterate over each block of fit parameters in the file
     #each block corresponds to a single column in the final workspace
-    for block_num in xrange(num_blocks):
+    for block_num in range(num_blocks):
         lower_index = header_offset+(block_size*block_num)
         upper_index = lower_index+block_size
 
@@ -228,12 +229,12 @@ def read_ql_file(file_name, nl):
         line_pointer = yield_floats(asc[lower_index:upper_index])
 
         #Q,AMAX,HWHM,BSCL,GSCL
-        line = line_pointer.next()
+        line = next(line_pointer)
         Q, AMAX, HWHM, _, _ = line
         q_data.append(Q)
 
         #A0,A1,A2,A4
-        line = line_pointer.next()
+        line = next(line_pointer)
         block_height = AMAX*line[0]
 
         #parse peak data from block
@@ -241,7 +242,7 @@ def read_ql_file(file_name, nl):
         block_amplitude = []
         for _ in range(nl):
             #Amplitude,FWHM for each peak
-            line = line_pointer.next()
+            line = next(line_pointer)
             amp = AMAX*line[0]
             FWHM = 2.*HWHM*line[1]
             block_amplitude.append(amp)
@@ -249,7 +250,7 @@ def read_ql_file(file_name, nl):
 
         #next parse error data from block
         #SIG0
-        line = line_pointer.next()
+        line = next(line_pointer)
         block_height_e = line[0]
 
         block_FWHM_e = []
@@ -257,12 +258,12 @@ def read_ql_file(file_name, nl):
         for _ in range(nl):
             #Amplitude error,FWHM error for each peak
             #SIGIK
-            line = line_pointer.next()
+            line = next(line_pointer)
             amp = AMAX*math.sqrt(math.fabs(line[0])+1.0e-20)
             block_amplitude_e.append(amp)
 
             #SIGFK
-            line = line_pointer.next()
+            line = next(line_pointer)
             FWHM = 2.0*HWHM*math.sqrt(math.fabs(line[0])+1.0e-20)
             block_FWHM_e.append(FWHM)
 
@@ -676,9 +677,9 @@ def ResNormRun(vname,rname,erange,nbin,Plot='None',Save=False):
     nvan,ntc = CheckHistZero(vname)
     theta = GetThetaQ(vname)[0]
     efix = getEfixed(vname)
-    print "begining erange calc"
+    print("begining erange calc")
     nout,bnorm,Xdat,Xv,Yv,Ev = CalcErange(vname,0,erange,nbin)
-    print "end of erange calc"
+    print("end of erange calc")
     Ndat = nout[0]
     Imin = nout[1]
     Imax = nout[2]

--- a/indirect_inelastic/ISIS/Bayes/Water/IndirectBayes.py
+++ b/indirect_inelastic/ISIS/Bayes/Water/IndirectBayes.py
@@ -3,6 +3,7 @@
 # Input : the Python list is padded to Fortrans length using procedure PadArray
 # Output : the Fortran numpy array is sliced to Python length using dataY = yout[:ny]
 #
+from __future__ import print_function
 from IndirectImport import *
 if is_supported_f2py_platform():
     QLr     = import_f2py("QLres")
@@ -129,7 +130,7 @@ def ReadWidthFile(readWidth,widthFile,numSampleGroups):
 				asc.append(line)
 			handle.close()
 
-		except Exception, e:
+		except Exception as e:
 			raise ValueError('Failed to read width file')
 
 		numLines = len(asc)
@@ -414,7 +415,7 @@ def read_ql_file(file_name, nl):
 	amp_error, FWHM_error, height_error = [], [], []
 
 	#iterate over each block of fit parameters in the file
-	for block_num in xrange(num_blocks):
+	for block_num in range(num_blocks):
 		lower_index = header_offset+(block_size*block_num)
 		upper_index = lower_index+block_size 
 		
@@ -422,12 +423,12 @@ def read_ql_file(file_name, nl):
 		line_pointer = yield_floats(asc[lower_index:upper_index])
 
 		#Q,AMAX,HWHM,BSCL,GSCL
-		line = line_pointer.next()
+		line = next(line_pointer)
 		Q, AMAX, HWHM, BSCL, GSCL = line
 		q_data.append(Q)
 
 		#A0,A1,A2,A4
-		line = line_pointer.next()
+		line = next(line_pointer)
 		block_height = AMAX*line[0]
 
 		#parse peak data from block
@@ -435,7 +436,7 @@ def read_ql_file(file_name, nl):
 		block_amplitude = []
 		for i in range(nl):		
 			#Amplitude,FWHM for each peak
-			line = line_pointer.next()
+			line = next(line_pointer)
 			amp = AMAX*line[0]
 			FWHM = 2.*HWHM*line[1]
 			block_amplitude.append(amp)
@@ -443,7 +444,7 @@ def read_ql_file(file_name, nl):
 		
 		#next parse error data from block
 		#SIG0
-		line = line_pointer.next()
+		line = next(line_pointer)
 		block_height_e = line[0]
 		
 		block_FWHM_e = []
@@ -451,12 +452,12 @@ def read_ql_file(file_name, nl):
 		for i in range(nl):
 			#Amplitude error,FWHM error for each peak
 			#SIGIK
-			line = line_pointer.next()
+			line = next(line_pointer)
 			amp = AMAX*math.sqrt(math.fabs(line[0])+1.0e-20)
 			block_amplitude_e.append(amp)
 			
 			#SIGFK
-			line = line_pointer.next()
+			line = next(line_pointer)
 			FWHM = 2.0*HWHM*math.sqrt(math.fabs(line[0])+1.0e-20)
 			block_FWHM_e.append(FWHM)
 	
@@ -880,9 +881,9 @@ def ResNormRun(vname,rname,erange,nbin,Verbose=False,Plot='None',Save=False):
 	theta,Q = GetThetaQ(vname)
 	efix = getEfixed(vname)
 	nres,ntr = CheckHistZero(rname)
-	print "begining erange calc"
+	print("begining erange calc")
 	nout,bnorm,Xdat,Xv,Yv,Ev = CalcErange(vname,0,erange,nbin)
-	print "end of erange calc"
+	print("end of erange calc")
 	Ndat = nout[0]
 	Imin = nout[1]
 	Imax = nout[2]

--- a/indirect_inelastic/models/StretchedExpFT/lmfit/strexpft.py
+++ b/indirect_inelastic/models/StretchedExpFT/lmfit/strexpft.py
@@ -168,7 +168,7 @@ def test_lineshapes(tau, beta, y):
     params = model.guess(y, x=None)
     # Stray away from optimal parameters
     [params[name].set(value=val) for name, val in
-     dict(amplitude=3.0, center=0.0002, tau=50.0, beta=1.5).items()]
+     list(dict(amplitude=3.0, center=0.0002, tau=50.0, beta=1.5).items())]
     r = model.fit(y, params, x=x)
     all_params = 'tau beta amplitude center'.split()
     assert_allclose([tau, beta, 1.0, 0.0],

--- a/indirect_inelastic/models/StretchedExpFT/v3.6/fitStretchedExFT.py
+++ b/indirect_inelastic/models/StretchedExpFT/v3.6/fitStretchedExFT.py
@@ -2,6 +2,7 @@
                   Script to fit QENS data to a particular model
                   This script should be run in the "Script Window" of MantidPlot
 '''
+from __future__ import print_function
 from copy import copy
 
 # Data directory
@@ -61,7 +62,7 @@ initguess = { 'f0.Scaling'   :   0.03,  # intensity of the elastic line
               'f1.f1.beta'   :   1.0,   # exponent
 }
 
-names = initguess.keys()  # Store the names of the parameters in a list
+names = list(initguess.keys())  # Store the names of the parameters in a list
 
 chi2 = []     # store the Chi-square values of the fits for every Q
 results = []  # we will store in this list the fitted parameters for every Q
@@ -81,11 +82,11 @@ for iq in range(nq):
         fitstring = fitstring_template.replace( 'iQ', str(iq) )
 
         # Update the model template string with the initial guess
-        for key, value in initguess.items():
+        for key, value in list(initguess.items()):
                 fitstring = fitstring.replace( key, str( value ) )
 
         # Call the Fit algorithm using the updated "fitstring".
-        print fitstring+'\n'
+        print(fitstring+'\n')
         Fit( fitstring, InputWorkspace = 'data', WorkspaceIndex = iq,
         CreateOutput = 1, startX = minE, endX = maxE,
         MaxIterations=100 )
@@ -137,7 +138,7 @@ for iq in range(nq):
 # Save some selected parameters to a string.
 # Remember that only the selected spectra contain data.
 buffer = '#  Q    Chi2   tau(ps) beta\n'
-print buffer
+print(buffer)
 for iq in range( nq ):
         if iq not in selected_wi:
                 continue # skip to next workspace index
@@ -147,7 +148,7 @@ for iq in range( nq ):
                                                            chi2[ iq ],
                                                            result['f1.f1.tau'],
                                                            result['f1.f1.beta'])
-        print line
+        print(line)
         buffer += line
 
 # Save the string to file "results_StretchedExpFT.dat" whithin the data dir

--- a/indirect_inelastic/models/StretchedExpFT/v3.7/fitStretchedExFT.py
+++ b/indirect_inelastic/models/StretchedExpFT/v3.7/fitStretchedExFT.py
@@ -2,6 +2,7 @@
                   Script to fit QENS data to a the Fourier trasnform of a stretched exponential
                   This script should be run in the "Script Window" of MantidPlot
 '''
+from __future__ import print_function
 from copy import copy
 
 # Data directory
@@ -46,7 +47,7 @@ fitstring_template = """
 );name=LinearBackground,A0=0,A1=0"""
 '''
 fitstring_template = fitstring_template.strip(' \t\n\r')  # remove whitespaces and such
-print fitstring_template
+print(fitstring_template)
 
 # Load the data. We assume the format is DAVE group file.
 #  Use the "LoadDaveGrp" algorithm
@@ -83,7 +84,7 @@ initguess = { 'f0.f0.Scaling'   :   1.0,   # Overall intensity
               'f0.f1.f1.Beta'   :   1.0,   # exponent
 }
 
-names = initguess.keys()  # Store the names of the parameters in a list
+names = list(initguess.keys())  # Store the names of the parameters in a list
 
 chi2 = []     # store the Chi-square values of the fits for every Q
 results = []  # we will store in this list the fitted parameters for every Q
@@ -103,11 +104,11 @@ for iq in range(nq):
         fitstring = fitstring_template.replace( 'iQ', str(iq) )
 
         # Update the model template string with the initial guess
-        for key, value in initguess.items():
+        for key, value in list(initguess.items()):
                 fitstring = fitstring.replace( key, str( value ) )
 
         # Call the Fit algorithm using the updated "fitstring".
-        print fitstring+'\n'
+        print(fitstring+'\n')
         Fit( fitstring, InputWorkspace = 'data', WorkspaceIndex = iq,
         CreateOutput = 1, startX = minE, endX = maxE,
         MaxIterations=200 )
@@ -159,7 +160,7 @@ for iq in range(nq):
 # Save some selected parameters to a string.
 # Remember that only the selected spectra contain data.
 buffer = '#  Q    Chi2   x   Tau(ps) Beta\n'
-print buffer,
+print(buffer, end=' ')
 for iq in range( nq ):
         if iq not in selected_wi:
                 continue # skip to next workspace index
@@ -170,7 +171,7 @@ for iq in range( nq ):
             result['f0.f1.f0.Height'],
             result['f0.f1.f1.Tau'],
             result['f0.f1.f1.Beta'])
-        print line,
+        print(line, end=' ')
         buffer += line
 
 # Save the string to file "results_StretchedExpFT.dat" whithin the data dir

--- a/indirect_inelastic/models/StretchedExpFT/v3.8.0/seqFitStretchedExFT.py
+++ b/indirect_inelastic/models/StretchedExpFT/v3.8.0/seqFitStretchedExFT.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 import sys
 import string
 import re
@@ -161,7 +162,7 @@ class FitWorker(object):
         names = list()
         Y = list()
         E = list()
-        for prop, key in self._alg._propvalue2key.iteritems():
+        for prop, key in self._alg._propvalue2key.items():
             names.append(prop)
             values, errors = self.extractOptimalParameter(key.replace('_','.'))
             Y += values

--- a/indirect_inelastic/models/StretchedExpFT/v3.8/algorithm_version/seqFitStretchedExFT.py
+++ b/indirect_inelastic/models/StretchedExpFT/v3.8/algorithm_version/seqFitStretchedExFT.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import string
 import re
@@ -82,7 +83,7 @@ class FitWorker(object):
             if mapi.AnalysisDataService.doesExist(outputWorkspace):
                 workspaceGroup = mapi.mtd[outputWorkspace]
                 for workspace in workspaceGroup:
-                    print workspace.name()
+                    print(workspace.name())
                     mapi.AnalysisDataService.remove(workspace.name())
                 mapi.AnalysisDataService.remove(outputWorkspace)
         for suffix in ("_Qdependence", "_QQdependence"):
@@ -110,7 +111,7 @@ class FitWorker(object):
             # 2: reference to the table workspace containing correlations between pair of parameters
             # 3: reference to the table workspace containing optimal parameter values
             # 4: reference to MatrixWorkspace containing the data, fit, and difference curves
-            print self._alg._applyGuess(wi=wi)
+            print(self._alg._applyGuess(wi=wi))
             try:
                 fitreport = msapi.Fit(self._alg._applyGuess(wi=wi),
                                       InputWorkspace=self._alg.getPropertyValue("DataWorkspace"),
@@ -160,7 +161,7 @@ class FitWorker(object):
         names = list()
         Y = list()
         E = list()
-        for prop, key in self._alg._propvalue2key.iteritems():
+        for prop, key in self._alg._propvalue2key.items():
             names.append(prop)
             values, errors = self.extractOptimalParameter(key.replace('_','.'))
             Y += values

--- a/indirect_inelastic/models/StretchedExpFTBkgrd/v3.8/seqFitStretchedExFTBkgrd.py
+++ b/indirect_inelastic/models/StretchedExpFTBkgrd/v3.8/seqFitStretchedExFTBkgrd.py
@@ -7,6 +7,7 @@
 Script to sequential fit of QENS data to a the Fourier trasnform of a stretched exponential
 This script should be run in the "Script Window" of MantidPlot
 """
+from __future__ import print_function
 import re
 from copy import copy
 import numpy as np
@@ -65,7 +66,7 @@ def doFit(resolution, data, background, fitstring_template, initguess, erange, q
     fitstring_template = fitstring_template.replace("_BACKGROUND_", background.name())
     minE, maxE = erange  # Units are in meV
     nq = len(qvalues)
-    names = initguess.keys()  # Store the names of the parameters in a list
+    names = list(initguess.keys())  # Store the names of the parameters in a list
     chi2 = []     # store the Chi-square values of the fits for every Q
     results = []  # we will store in this list the fitted parameters for every Q
     errors = []  # we will store in this list the errors of fitted parameters for every Q
@@ -88,11 +89,11 @@ def doFit(resolution, data, background, fitstring_template, initguess, erange, q
         funcString = fitstring_template.replace( '_IQ_', str(iq) )
 
         # Update the model template string with the initial guess
-        for key, value in initguess.items():
+        for key, value in list(initguess.items()):
             fitstring = fitstring.replace( key, str( value ) )
 
         # Call the Fit algorithm using the updated "fitstring".
-        print fitstring+'\n'
+        print(fitstring+'\n')
         msapi.Fit( fitstring, InputWorkspace=dataName, WorkspaceIndex=iq,
                    CreateOutput=1, startX=minE, endX=maxE,
                    Minimizer=minimizer, MaxIterations=maxIterations )
@@ -115,7 +116,7 @@ def doFit(resolution, data, background, fitstring_template, initguess, erange, q
             if name == 'Cost function value':  # store Chi-square separately
                 chi2.append(row['Value'])
         # Save the string representation with optimal values
-        for key, value in initguess.items():
+        for key, value in list(initguess.items()):
             funcString = funcString.replace(key, str(value))
         funcStrings.append(funcString)
             
@@ -155,7 +156,7 @@ def doFit(resolution, data, background, fitstring_template, initguess, erange, q
     # Save some selected parameters to a string.
     # Remember that only the selected spectra contain data.
     buffer = '#Sequential fit summary\n#  Q    Chi2 Tau(ps)+-error  Beta+-error\n'
-    print buffer,
+    print(buffer, end=' ')
     for iq in range( nq ):
         if iq not in selectedwi:
             continue # skip to next workspace index
@@ -166,7 +167,7 @@ def doFit(resolution, data, background, fitstring_template, initguess, erange, q
             chi2[ iq ],
             result['f0.f1.f1.Tau'], error['f0.f1.f1.Tau'],
             result['f0.f1.f1.Beta'], error['f0.f1.f1.Beta'])
-        print line,
+        print(line, end=' ')
         buffer += line
 
     # Save Q-dependence of parameters to a Workspace
@@ -178,14 +179,14 @@ def doFit(resolution, data, background, fitstring_template, initguess, erange, q
         # python dictionary holding  results for the fit of this workspace index
         result = results[ iq ]
         error = errors[iq]
-        for key,value in result.items():
-            if key not in other.keys():
+        for key,value in list(result.items()):
+            if key not in list(other.keys()):
                 other[key] = np.array([value,])
                 other_error[key] = np.array([error[key],])
             else:
                 other[key] = np.append(other[key], value)
                 other_error[key] = np.append(other_error[key], error[key])
-        if "Chi2" not in other.keys():
+        if "Chi2" not in list(other.keys()):
             other["Chi2"] = np.array([chi2[iq],])
             other_error["Chi2"] = np.array([0.0,])  # no error in the optimal Chi2
         else:
@@ -227,7 +228,7 @@ if __name__ == "__main__":
     vertical_axis = data.getAxis(1)
     qvalues = vertical_axis.extractValues()
     if not selected_wi:
-        selected_wi=range(len(qvalues))
+        selected_wi=list(range(len(qvalues)))
 
     """ Fitting model. In this case:
         Convolution( Resolution, A*Delta + B*StretchedExFT ) + LinearBackground + BackgroundFile

--- a/indirect_inelastic/models/StretchedExpFTTauQ/v3.8/StretchedExpFTTauQ.py
+++ b/indirect_inelastic/models/StretchedExpFTTauQ/v3.8/StretchedExpFTTauQ.py
@@ -44,8 +44,8 @@ class StretchedExpFTTauQ(IFunction1D):
         qmin = self.getAttributeValue("Qmin")
         q = self.getAttributeValue("Q")
 
-        for _, value in {'Height': height, 'TauMax': taumax, 'Alpha': alpha,
-                         'Beta': beta, 'Qmin': qmin, 'Q': q}.items():
+        for _, value in list({'Height': height, 'TauMax': taumax, 'Alpha': alpha,
+                         'Beta': beta, 'Qmin': qmin, 'Q': q}.items()):
             if value <= 0:
                 return None
         return {'Height': height, 'TauMax': taumax, 'Alpha': alpha, 'Beta': beta,

--- a/indirect_inelastic/models/StretchedExpFTTauQ/v3.8/seqFitStretchedExFTTauQ.py
+++ b/indirect_inelastic/models/StretchedExpFTTauQ/v3.8/seqFitStretchedExFTTauQ.py
@@ -8,7 +8,6 @@ Sequential fit of QENS data to the Fourier trasnform of a stretched exponential
     Relaxation time follows a power-law: tau = taumax * (Qmin/Q)**alpha
     This script should be run in the "Script Window" of MantidPlot
 '''
-from __future__ import print_function
 
 from __future__ import (absolute_import, division, print_function)
 import re

--- a/indirect_inelastic/models/StretchedExpFTTauQ/v3.8/seqFitStretchedExFTTauQ.py
+++ b/indirect_inelastic/models/StretchedExpFTTauQ/v3.8/seqFitStretchedExFTTauQ.py
@@ -8,6 +8,7 @@ Sequential fit of QENS data to the Fourier trasnform of a stretched exponential
     Relaxation time follows a power-law: tau = taumax * (Qmin/Q)**alpha
     This script should be run in the "Script Window" of MantidPlot
 '''
+from __future__ import print_function
 
 from __future__ import (absolute_import, division, print_function)
 import re
@@ -130,7 +131,7 @@ def sequentialFit(resolution, data, fitstring_template, initguess, erange, qvalu
     fitstring_template = fitstring_template.replace("_RESOLUTION_", resolution.name())
     minE, maxE = erange  # Units are in meV
     nq = len(qvalues)
-    names = initguess.keys()  # Store the names of the parameters in a list
+    names = list(initguess.keys())  # Store the names of the parameters in a list
     chi2 = []     # store the Chi-square values of the fits for every Q
     results = []  # we will store in this list the fitted parameters for every Q
     funcStrings = []  # store the fitstring with the optimized values
@@ -151,7 +152,7 @@ def sequentialFit(resolution, data, fitstring_template, initguess, erange, qvalu
         funcString = funcString.replace("_Q_", str(qvalues[iq])) # momentum transfer
 
         # Update the model template string with the initial guess
-        for key, value in initguess.items():
+        for key, value in list(initguess.items()):
                 fitstring = fitstring.replace( key, str( value ) )
 
         # Call the Fit algorithm using the updated "fitstring".
@@ -177,7 +178,7 @@ def sequentialFit(resolution, data, fitstring_template, initguess, erange, qvalu
                         chi2.append(row['Value'])
 
         # Save the string representation with optimal values
-        for key, value in initguess.items():
+        for key, value in list(initguess.items()):
             funcString = funcString.replace(key, str(value))
         funcStrings.append(funcString)
 
@@ -227,12 +228,12 @@ def sequentialFit(resolution, data, fitstring_template, initguess, erange, qvalu
                 continue # skip to next workspace index
         # python dictionary holding  results for the fit of this workspace index
         result = results[ iq ]
-        for key,value in result.items():
-            if key not in other.keys():
+        for key,value in list(result.items()):
+            if key not in list(other.keys()):
                 other[key] = [value,]
             else:
                 other[key].append(value)
-        if "Chi2" not in other.keys():
+        if "Chi2" not in list(other.keys()):
             other["Chi2"] = [chi2[ iq ],]
         else:
             other["Chi2"].append(chi2[ iq ])

--- a/indirect_inelastic/models/TeixeiraWaterSQE/v3.9/algTeixeiraWaterFit.py
+++ b/indirect_inelastic/models/TeixeiraWaterSQE/v3.9/algTeixeiraWaterFit.py
@@ -82,7 +82,7 @@ class TeixeiraWaterFit(DataProcessorAlgorithm):
 
         # Do the fit using only these workspaces
         #selected_wi = [ 0, 3, 4, 7] # select a few workspace indexes
-        selected_wi = range(len(Qs))  # use all spectra for the fit
+        selected_wi = list(range(len(Qs)))  # use all spectra for the fit
         nWi=len(selected_wi)  # number of selected spectra for fitting
 
         # Energy range over which we do the fitting.
@@ -98,8 +98,8 @@ class TeixeiraWaterFit(DataProcessorAlgorithm):
             global_model += "(composite=CompositeFunction,NumDeriv=true,$domains=i;{0});\n".format(single_model)
 
         # Tie DiffCoeff and Tau since they are global parameters
-        ties=['='.join(["f{0}.f0.f1.f1.DiffCoeff".format(di) for di in reversed(range(nWi))]),
-        '='.join(["f{0}.f0.f1.f1.Tau".format(wi) for wi in reversed(range(nWi))]) ]
+        ties=['='.join(["f{0}.f0.f1.f1.DiffCoeff".format(di) for di in reversed(list(range(nWi)))]),
+        '='.join(["f{0}.f0.f1.f1.Tau".format(wi) for wi in reversed(list(range(nWi)))]) ]
         global_model += "ties=("+','.join(ties)+')'  # tie Radius
 
         # Now relate each domain(i.e. spectrum) to each single-spectrum model
@@ -128,9 +128,9 @@ class TeixeiraWaterFit(DataProcessorAlgorithm):
         parameters_workspace = mtd[output_workspace + "_Parameters"]
         aliases = {"f0.f1.f0.Height": "Ha", "f0.f1.f1.Height": "Hb", "f0.f1.f1.Tau": "tau", "f0.f1.f1.DiffCoeff": "diffCoeff"}
         optimals = dict()
-        for alias in aliases.values():
+        for alias in list(aliases.values()):
             optimals[alias] = list()
-        names = aliases.keys()
+        names = list(aliases.keys())
         for row in parameters_workspace:
         # name of the fitting parameter for this particular row
             matches = re.search("^f(\d+)\.(.*)", row['Name']) # for instance, f0.f0.f1.f0.Height

--- a/indirect_inelastic/models/TeixeiraWaterSQE/v3.9/gloFitTeixeiraWaterSQE.py
+++ b/indirect_inelastic/models/TeixeiraWaterSQE/v3.9/gloFitTeixeiraWaterSQE.py
@@ -40,7 +40,7 @@ resolution=mtd[resolution_name]
 Qs=GetQsInQENSData(data)
 nQ=len(Qs)
 if not selected_wi:
-    selected_wi = range(0,len(Qs))
+    selected_wi = list(range(0,len(Qs)))
 
 """ Below is the model cast as a template string suitable for the
     Fit algoritm of Mantid. You can obtain similar string by setting up a model
@@ -69,8 +69,8 @@ for wi in selected_wi:
     global_model += "(composite=CompositeFunction,NumDeriv=true,$domains=i;{0});\n".format(single_model)
 
 # Tie DiffCoeff and Tau since they are global parameters
-ties=['='.join(["f{0}.f0.f1.f1.DiffCoeff".format(di) for di in reversed(range(nWi))]),
-    '='.join(["f{0}.f0.f1.f1.Tau".format(wi) for wi in reversed(range(nWi))]) ]
+ties=['='.join(["f{0}.f0.f1.f1.DiffCoeff".format(di) for di in reversed(list(range(nWi)))]),
+    '='.join(["f{0}.f0.f1.f1.Tau".format(wi) for wi in reversed(list(range(nWi)))]) ]
 global_model += "ties=("+','.join(ties)+')'  # tie Radius
 
 # Now relate each domain(i.e. spectrum) to each single-spectrum model
@@ -94,9 +94,9 @@ Fit(Function=global_model, Output=output_workspace, CreateOutput=True, MaxIterat
 parameters_workspace = mtd[output_workspace+"_Parameters"]
 aliases = {"f0.f1.f0.Height": "Ha", "f0.f1.f1.Height": "Hb", "f0.f1.f1.Tau": "tau", "f0.f1.f1.DiffCoeff": "diffCoeff"}
 optimals = dict()
-for alias in aliases.values():
+for alias in list(aliases.values()):
     optimals[alias] = list()
-names = aliases.keys()
+names = list(aliases.keys())
 for row in parameters_workspace:
     # name of the fitting parameter for this particular row
     matches = re.search("^f(\d+)\.(.*)", row['Name']) # for instance, f0.f0.f1.f0.Height

--- a/indirect_inelastic/models/twoLorentziansPlusLinearBackground.py
+++ b/indirect_inelastic/models/twoLorentziansPlusLinearBackground.py
@@ -2,6 +2,7 @@
  - Sequential fitting
  - Plot several quantities
 """
+from __future__ import print_function
 
 import re
 from os import path
@@ -38,7 +39,7 @@ function_string=\
    )"""
    
 function_string=re.sub(r"[\s\t\n]", "", function_string)  #remove spaces,tabs,newlines
-print function_string
+print(function_string)
 #Sequential fitting (more info in http://docs.mantidproject.org/nightly/algorithms/PlotPeakByLogValue-v1.html)
 inputs=';'.join([signal.name() + ',i%d' % i for i in range(signal.getNumberHistograms())])
 fitSeq=PlotPeakByLogValue(inputs,
@@ -80,18 +81,18 @@ ws=ExtractSpectra("signal_0_Workspace",StartWorkspaceIndex=0,EndWorkspaceIndex=1
 for i in range(1, signal.getNumberHistograms()):
     ws2 = ExtractSpectra("signal_"+str(i)+"_Workspace",StartWorkspaceIndex=0,EndWorkspaceIndex=1)
     ws = AppendSpectra(ws,ws2)
-plotSpectrum(ws, indices=range(ws.getNumberHistograms()),waterfall=1)
+plotSpectrum(ws, indices=list(range(ws.getNumberHistograms())),waterfall=1)
 
 #Prepare output for plotting the parameters (this is always the same, could be packaged into some function)
 column_names=fitSeq.getColumnNames()  #names of all fitting parameters
-print column_names
+print(column_names)
 n_parameters = (len(column_names)-2)/2
 x=fitSeq.column(0)*n_parameters
 y=list()
 for i in range(1,len(column_names)-1,2): y += fitSeq.column(i)
 yerr=list()
 for i in range(2,len(column_names)-1,2): yerr += fitSeq.column(i)
-print n_parameters,len(x),len(y),len(yerr)
+print(n_parameters,len(x),len(y),len(yerr))
 parms=CreateWorkspace(x,y,yerr,NSpec=n_parameters,UnitX="MomentumTransfer")
 
 #Plot the FWHM's

--- a/muon/AnalyseThresholdScans6.py
+++ b/muon/AnalyseThresholdScans6.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.kernel import *
 from mantid.api import *
 import math
@@ -77,13 +78,13 @@ class AnalyseThresholdScans(PythonAlgorithm):
 	  
 	  #self.progress(0.25*vi/numruns)
 	  try:
-	    print "calling LoadMuonNexus with ",thisrunpath," and ",thisrunname
+	    print("calling LoadMuonNexus with ",thisrunpath," and ",thisrunname)
 	    thisoneX=LoadMuonNexus(filename=thisrunpath,OutputWorkspace=thisrunname,AutoGroup=agroup)
 	  except:
-	    print "no more runs to load"
+	    print("no more runs to load")
 	    break
 	  thisone=thisoneX[0]
-	  print "Comment field: [",thisone.getComment(),"]"
+	  print("Comment field: [",thisone.getComment(),"]")
 	  comnt=thisone.getComment()
 	  mv=comnt.find("mV")
 	  try:
@@ -94,7 +95,7 @@ class AnalyseThresholdScans(PythonAlgorithm):
 	    voltlist.append(volts)
 	    runnames.append(thisrunname)
 	    runhandles.append(thisone)
-	    print "threshold incrementing from ",oldvolts," to ",volts
+	    print("threshold incrementing from ",oldvolts," to ",volts)
 	    oldvolts=volts
 	  else:
 	    oldvolts=999999
@@ -115,7 +116,7 @@ class AnalyseThresholdScans(PythonAlgorithm):
 	  vi=vi+1
 
 	numruns=len(voltlist)
-	print "found sequence of ",numruns," runs with thresholds between ",voltlist[0]," and ",voltlist[-1]," mV"
+	print("found sequence of ",numruns," runs with thresholds between ",voltlist[0]," and ",voltlist[-1]," mV")
 
 # fitting..
 
@@ -162,7 +163,7 @@ class AnalyseThresholdScans(PythonAlgorithm):
 		  if(fr.cell("Value",1)<0):
 		   phfitted=phfitted+3.14159265 # correct for phase jumping negative
 		   afitted=-afitted
-		  print "hist ",i," freq=",bfitted," ampl=",afitted," phase ",phfitted," tau=", taufitted
+		  print("hist ",i," freq=",bfitted," ampl=",afitted," phase ",phfitted," tau=", taufitted)
 		  if(fml):
 			  taufitted=2.19703
 		  for vi in range(0,len(voltlist)):
@@ -329,7 +330,7 @@ class AnalyseThresholdScans(PythonAlgorithm):
 	    try:
 	      resw.dataE(i)[j]=fr.cell("Error",j)
 	    except:
-	      print "missing Error column from fit"
+	      print("missing Error column from fit")
 	      resw.dataE(i)[j]=0.0
 	  resw.dataX(i)[3]=5.0
 	  #print "fitted pulse height spectrum ",i," with mean=",fr.getDouble("Value",1)

--- a/muon/AnalyseThresholdScans9.py
+++ b/muon/AnalyseThresholdScans9.py
@@ -168,7 +168,7 @@ class AnalyseThresholdScans(PythonAlgorithm):
 						thisoneY=self.doChildAlg(loadInstAlg,Workspace=thisoneX1["OutputWorkspace"],RewriteSpectraMap=False,Filename=self.getProperty("IDF").value)
 					dgt=self.getProperty("GroupingTable").value
 					glist=[dgt.cell(iii,0) for iii in range(dgt.rowCount())]
-					gpat=",".join(map(lambda x:"+".join(map(lambda y:str(y-1),x)),glist))
+					gpat=",".join(["+".join([str(y-1) for y in x]) for x in glist])
 					thisoneX=self.doChildAlg(groupDetAlg,InputWorkspace=thisoneX1["OutputWorkspace"],GroupingPattern=gpat,OutputWorkspace=thisrunname)
 					#thisoneX=self.doChildAlg("MuonGroupDetectors",InputWorkspace=thisoneX1["OutputWorkspace"],DetectorGroupingTable=dgt,OutputWorkspace=thisrunname)
 				#thisoneX=LoadMuonNexus(filename=thisrunpath,OutputWorkspace=thisrunname,AutoGroup=agroup,DetectorGroupingTable="dgt")
@@ -327,7 +327,7 @@ class AnalyseThresholdScans(PythonAlgorithm):
 			#fitalg.setProperty("")
 			fitalg=self.doChildAlg(fitAlg,InputWorkspace=bulkasym,Function=str(bulkfunc),StartX=t1,EndX=t1+12.0,CreateOutput=True,OutputParametersOnly=True,Output="bulk")
 			#ff=Fit(InputWorkspace=bulkasym,Function=bulkfunc,StartX=t1,EndX=t1+12.0,CreateOutput=True,Output="bulk")
-			fr=dict(map(lambda r:(r["Name"],r["Value"]),fitalg["OutputParameters"]))
+			fr=dict([(r["Name"],r["Value"]) for r in fitalg["OutputParameters"]])
 			bfitted=fr["f0.Frequency"]*2*math.pi
 			lamfitted=fr["f0.Lambda"]
 			phizero=fr["f0.Phi"]
@@ -374,7 +374,7 @@ class AnalyseThresholdScans(PythonAlgorithm):
 							InputWorkspace=sumd,StartX=t1,EndX=t1+12,CreateOutput=True,OutputParametersOnly=True,Ties=",".join(ties),WorkspaceIndex=i)
 						#ff=Fit(Function="name=UserFunction, Formula=1/(1/(n*(1+a*cos(x*"+str(bfitted)+"+p)*exp(-x/"+str(lamfitted)+"))*exp(-x/tau)+b)+d), n="+str(nguess)+", a=0.2, p="+str(phguess)+", b=0.01, d=0.001, tau=2.19703",
 						#	InputWorkspace="Summed",StartX=t1,EndX=t1+12,Output="fitresSpec",Ties=",".join(ties),WorkspaceIndex=i)
-						fr=dict(map(lambda r:(r["Name"],r["Value"]),ff["OutputParameters"]))
+						fr=dict([(r["Name"],r["Value"]) for r in ff["OutputParameters"]])
 						afitted=fr["a"]
 						#bfitted=fr["b"]
 						phfitted=fr["p"]
@@ -415,7 +415,7 @@ class AnalyseThresholdScans(PythonAlgorithm):
 						elif(bbefore<32):
 							ff=self.doChildAlg(fitAlg,Function=str(FlatBackground()),InputWorkspace=runhandles[vi],WorkspaceIndex=i,StartX=-999.0,EndX=bbefore,CreateOutput=True,OutputParametersOnly=True)
 							#ff=Fit(Function=FlatBackground(),InputWorkspace=runnames[vi],WorkspaceIndex=i,StartX=-999.0,EndX=bbefore)
-							frbg=dict(map(lambda r:(r["Name"],r["Value"]),ff["OutputParameters"]))
+							frbg=dict([(r["Name"],r["Value"]) for r in ff["OutputParameters"]])
 							ties.append("b="+str(frbg["A0"]))
 						if(not indPhases):
 							ties.append("p="+str(phfitted))
@@ -424,8 +424,8 @@ class AnalyseThresholdScans(PythonAlgorithm):
 							InputWorkspace=runhandles[vi],WorkspaceIndex=str(i),StartX=str(t1),EndX=32,CreateOutput=True,OutputParametersOnly=True,Ties=",".join(ties))
 						#ff=Fit(Function="name=UserFunction, Formula=1/(1/(n*(1+a*cos(x*"+str(bfitted)+"+p)*exp(-x*"+str(lamfitted)+"))*exp(-x/"+str(taufitted)+")+b)+d), n="+str(nguess)+", a=0.2, b=0.01, d=0.001, p="+str(phguess),
 						#	InputWorkspace=runnames[vi],WorkspaceIndex=str(i),StartX=str(t1),EndX=32,Output="fitres",Ties=",".join(ties))
-						fr=dict(map(lambda r:(r["Name"],r["Value"]),ff["OutputParameters"]))
-						fe=dict(map(lambda r:(r["Name"],r["Error"]),ff["OutputParameters"]))
+						fr=dict([(r["Name"],r["Value"]) for r in ff["OutputParameters"]])
+						fe=dict([(r["Name"],r["Error"]) for r in ff["OutputParameters"]])
 						Nfitted=fr["n"]
 						NfitE=fe["n"]
 						Afitted=fr["a"]
@@ -464,8 +464,8 @@ class AnalyseThresholdScans(PythonAlgorithm):
 						if(doPositrons):
 							ff=self.doChildAlg(fitAlg,Function=str(FlatBackground()),InputWorkspace=runhandles[vi],WorkspaceIndex=i,StartX=pktime-0.05,EndX=pktime+0.05,CreateOutput=True,OutputParametersOnly=True)
 							#ff=Fit(Function=FlatBackground(),InputWorkspace=runnames[vi],WorkspaceIndex=i,StartX=pktime-0.05,EndX=pktime+0.05,CreateOutput=True,Output="posfit")
-							pfr=dict(map(lambda r:(r["Name"],r["Value"]),ff["OutputParameters"]))
-							pfe=dict(map(lambda r:(r["Name"],r["Error"]),ff["OutputParameters"]))
+							pfr=dict([(r["Name"],r["Value"]) for r in ff["OutputParameters"]])
+							pfe=dict([(r["Name"],r["Error"]) for r in ff["OutputParameters"]])
 							procPos.dataX(i)[vi]=voltlist[vi]
 							procPos.dataY(i)[vi]=(pfr["A0"]-fr["b"])/nframes # counts/bin/frame
 							procPos.dataE(i)[vi]=pfe["A0"]/nframes # assume BG error is small by comparison
@@ -533,8 +533,8 @@ class AnalyseThresholdScans(PythonAlgorithm):
 							InputWorkspace=runhandles[vi],WorkspaceIndex=str(i),StartX=t1,EndX=t1+4,CreateOutput=True,OutputParametersOnly=True)
 						#ff=Fit(Function="name=UserFunction, Formula=1/(1/(n*exp(-x/tau)+b)+d), n="+str(nguess)+", b=0.01, d=0.001, tau=2.19703",
 						#	InputWorkspace=runnames[vi],WorkspaceIndex=str(i),StartX=str(t1),EndX=32,Output="fitres",Ties=",".join(ties))
-						fr=dict(map(lambda r:(r["Name"],r["Value"]),ff["OutputParameters"]))
-						fe=dict(map(lambda r:(r["Name"],r["Error"]),ff["OutputParameters"]))
+						fr=dict([(r["Name"],r["Value"]) for r in ff["OutputParameters"]])
+						fe=dict([(r["Name"],r["Error"]) for r in ff["OutputParameters"]])
 						proc.dataX(i)[vi]=voltlist[vi]
 						proc.dataY(i)[vi]=fr["A0"]/nframes/tres # counts/us/frame, mean including any BG
 						proc.dataE(i)[vi]=fe["A0"]/nframes/tres

--- a/muon/BeamCamSingleImageAnalyser4Emu.py
+++ b/muon/BeamCamSingleImageAnalyser4Emu.py
@@ -5,6 +5,7 @@ Uses classes from FlattenAndFitCamera.py and LoadBeamCameraFile.py
 Written by Koji Yokoyama on 23 Jan. 2019
 Hint: you will need to set: a scaling factor, initial values for fitting
 *WIKI*"""
+from __future__ import print_function
 
 import numpy
 import math
@@ -63,7 +64,7 @@ img=LoadBeamCameraFile(SourceFile=image_filename, FilterNoiseLevel='50', BinSize
 
 starttime=time.mktime(time.strptime(str(img.getRun().startTime()).strip(),"%Y-%m-%dT%H:%M:%S"))
 endtime=time.mktime(time.strptime(str(img.getRun().endTime()).strip(),"%Y-%m-%dT%H:%M:%S"))
-print "capture duration:", endtime-starttime, "sec \n Fit parameters:"
+print("capture duration:", endtime-starttime, "sec \n Fit parameters:")
 
 squash=MaskAndFlattenCameraImage(img,*mask)
 # Do fitting
@@ -92,19 +93,19 @@ XOverall=XSig/SFac
 YOverall=YSig/SFac
 Amplitude = Intens/XSig/YSig/math.sqrt(1+Skew**2/4) # peak
 
-print "X centre = ", X0
-print "Y centre = ", Y0
-print "Skew = ", Skew
-print "Background = ", Background
-print "Intensity = ", Intens
-print "Amplitude = ", Amplitude
-print "area1=",XOverall*YSig, " area2=",Major*Minor
+print("X centre = ", X0)
+print("Y centre = ", Y0)
+print("Skew = ", Skew)
+print("Background = ", Background)
+print("Intensity = ", Intens)
+print("Amplitude = ", Amplitude)
+print("area1=",XOverall*YSig, " area2=",Major*Minor)
 
 # Generates the result table with the parameter "par" and calculated fit params
 try:
 	tt = mtd["result_table"]
 except:
-	print "Workspace result_table doesn't exit. Creating one ..."
+	print("Workspace result_table doesn't exit. Creating one ...")
 	tt = WorkspaceFactory.createTable()
 	columns = [par_label,"X0","eX0","Y0","eY0","XSig","eXSig","YSig","eYSig","Skew","eSkew","Background","eBackground","Intens","eIntens","Major","Minor","Phi"]
 	for co in columns:

--- a/muon/CollateBeamCameraSteering.py
+++ b/muon/CollateBeamCameraSteering.py
@@ -253,7 +253,7 @@ for mag in mags:
 			Y0=fr[3].cell(0,1)
 			gradY=fr[3].cell(1,1)
 			DeleteWorkspace("tmpgrad")
-			print((mag,magref,X0,Y0,gradX,gradY))
+			print(mag,magref,X0,Y0,gradX,gradY))
 			tt2.addRow((mag,magref,X0,Y0,gradX,gradY))
 AnalysisDataService.addOrReplace(matrixname,tt2)
 

--- a/muon/CollateBeamCameraSteering.py
+++ b/muon/CollateBeamCameraSteering.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 import datetime
 import math
@@ -12,58 +13,58 @@ camfile="//ndlt626/Users/Public/Documents/sxvh9usb/Tune Sept2016/IMG%d.FIT"
 field=-4
 if(field==0):
 	# zero field
-	piclist= range(2820,3013)
-	runlist=range(108048,108068)
+	piclist= list(range(2820,3013))
+	runlist=list(range(108048,108068))
 	resultname="steeringZF2"
 	matrixname="steerMatZF2"
 elif(field==2500):
-	piclist= range(3013,3156)
-	runlist=range(108068,108088)
+	piclist= list(range(3013,3156))
+	runlist=list(range(108068,108088))
 	resultname="steering2500"
 	matrixname="steerMat2500"
 elif(field==5000):
-	piclist= range(3170,3278)
-	runlist=range(108088,108108)
+	piclist= list(range(3170,3278))
+	runlist=list(range(108088,108108))
 	resultname="steering5000"
 	matrixname="steerMat5000"
 elif(field==7500):
-	piclist= range(3278,3367)
-	runlist=range(108108,108128)
+	piclist= list(range(3278,3367))
+	runlist=list(range(108108,108128))
 	resultname="steering7500"
 	matrixname="steerMat7500"
 elif(field==10000):
-	piclist= range(3380,3478)
-	runlist=range(108128,108148)
+	piclist= list(range(3380,3478))
+	runlist=list(range(108128,108148))
 	resultname="steering10000"
 	matrixname="steerMat10000"
 elif(field==12500):
-	piclist= range(3478,3575)
-	runlist=range(108148,108168)
+	piclist= list(range(3478,3575))
+	runlist=list(range(108148,108168))
 	resultname="steering12500"
 	matrixname="steerMat12500"
 elif(field==15000):
-	piclist= range(3585,3671)
-	runlist=range(108168,108188)
+	piclist= list(range(3585,3671))
+	runlist=list(range(108168,108188))
 	resultname="steering15000"
 	matrixname="steerMat15000"
 elif(field==-1):
-	piclist= range(3722,3768)
-	runlist=range(108188,108200)
+	piclist= list(range(3722,3768))
+	runlist=list(range(108188,108200))
 	resultname="spotVsSlits"
 	matrixname="spotVsSlitsMat"
 elif(field==-2):
-	piclist= range(3782,3844)
-	runlist=range(108200,108204)
+	piclist= list(range(3782,3844))
+	runlist=list(range(108200,108204))
 	resultname="spotVsTFX"
 	matrixname="spotVsTFXMat"
 elif(field==-3):
-	piclist= range(3843,3883)
-	runlist=range(108204,108208)
+	piclist= list(range(3843,3883))
+	runlist=list(range(108204,108208))
 	resultname="spotVsTFY"
 	matrixname="spotVsTFYMat"
 elif(field==-4):
-	piclist= range(0,0)
-	runlist=range(108314,108323)
+	piclist= list(range(0,0))
+	runlist=list(range(108314,108323))
 	resultname="FlypastSlits40SEP"
 	matrixname="FlypastMat"
 # full fitted results
@@ -111,7 +112,7 @@ for run in runlist:
 	thisres["Field"]=ws.getRun().getProperty("sample_magn_field").value
 	thisres["Slits"]=ws.getRun().getProperty("Slits").value[-1]
 	results[run]=thisres
-print results
+print(results)
 #raise Exception("incomplete")
 
 tt=WorkspaceFactory.createTable()
@@ -133,9 +134,9 @@ for i in piclist: # range(5,405):
 	starttime=(datetime.datetime(*(time.strptime(img.getRun().getProperty("start_time").value.strip(),"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds()
 	endtime=(datetime.datetime(*(time.strptime(img.getRun().getProperty("end_time").value.strip(),"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds()
 	
-	for rn,r in results.items():
+	for rn,r in list(results.items()):
 		if(starttime>r["begin"] and endtime<r["end"]):
-			print "image",i,"taken during run",rn
+			print("image",i,"taken during run",rn)
 		
 			squash=MaskAndFlattenCameraImage(img,120,590,80,440)
 			
@@ -178,29 +179,29 @@ for i in piclist: # range(5,405):
 				r["XOverall"]=XSig/SFac
 				r["YOverall"]=YSig/SFac
 			except:
-				print "fit failed for image ",i
+				print("fit failed for image ",i)
 				# don't add to r, another image might be ok
 
 #print results
 
-for r in results.values():
+for r in list(results.values()):
 	if ("Image" in r) or (field==-4):
-		row=map(lambda x:r[x],columns)
+		row=[r[x] for x in columns]
 		tt.addRow(row)
 
 AnalysisDataService.addOrReplace(resultname,tt)
 
 # to test: select from here down, Execute Selection
 try:
-	print len(results)
+	print(len(results))
 except:
 	mm=mtd["steeringZF2"]
 	results={}
 	for r in mm:
-		print "Row->",r
+		print("Row->",r)
 		results[r["Run"]]=r
 
-print results
+print(results)
 
 # find sets
 if(field>=0):
@@ -219,9 +220,9 @@ for mag in mags:
 	del constmags[constmags.index(mag)]
 	sorter={}
 	common={}
-	for r in results.values():
+	for r in list(results.values()):
 		if "X0" in r:
-			key=tuple(map(lambda x:r[x],constmags))
+			key=tuple([r[x] for x in constmags])
 			if key not in sorter:
 				sorter[key]={}
 			sorter[key][r[mag]]=r
@@ -230,18 +231,18 @@ for mag in mags:
 			else:
 				common[r[mag]]=1
 		else:
-			print "run",r["Run"],"doesn't have a successfully fitted image"
-	magref=common.keys()[numpy.argmax(common.values())]
-	print mag,"relative to ",magref
-	for (sv,s) in sorter.items():
+			print("run",r["Run"],"doesn't have a successfully fitted image")
+	magref=list(common.keys())[numpy.argmax(list(common.values()))]
+	print(mag,"relative to ",magref)
+	for (sv,s) in list(sorter.items()):
 		if(len(s)>2):
 			# got a set of points
-			tmpM=numpy.array(map(lambda x:x[mag]-magref,s.values()))
-			print "found set of points for",constmags,"=",sv,"with",mag,"=",tmpM
-			tmpX=numpy.array(map(lambda x:x["X0"],s.values()))
-			tmpXe=numpy.array(map(lambda x:x["eX0"],s.values()))
-			tmpY=numpy.array(map(lambda x:x["Y0"],s.values()))
-			tmpYe=numpy.array(map(lambda x:x["eY0"],s.values()))
+			tmpM=numpy.array([x[mag]-magref for x in list(s.values())])
+			print("found set of points for",constmags,"=",sv,"with",mag,"=",tmpM)
+			tmpX=numpy.array([x["X0"] for x in list(s.values())])
+			tmpXe=numpy.array([x["eX0"] for x in list(s.values())])
+			tmpY=numpy.array([x["Y0"] for x in list(s.values())])
+			tmpYe=numpy.array([x["eY0"] for x in list(s.values())])
 			CreateWorkspace(DataX=tmpM,DataY=tmpX,DataE=tmpXe,NSpec=1,OutputWorkspace="tmpgrad")
 			fr=Fit(Function="name=LinearBackground",InputWorkspace="tmpgrad",Output="Xvs"+mag)
 			X0=fr[3].cell(0,1)
@@ -252,7 +253,7 @@ for mag in mags:
 			Y0=fr[3].cell(0,1)
 			gradY=fr[3].cell(1,1)
 			DeleteWorkspace("tmpgrad")
-			print (mag,magref,X0,Y0,gradX,gradY)
+			print((mag,magref,X0,Y0,gradX,gradY))
 			tt2.addRow((mag,magref,X0,Y0,gradX,gradY))
 AnalysisDataService.addOrReplace(matrixname,tt2)
 

--- a/muon/CollateBeamCameraSteering.py
+++ b/muon/CollateBeamCameraSteering.py
@@ -253,7 +253,7 @@ for mag in mags:
 			Y0=fr[3].cell(0,1)
 			gradY=fr[3].cell(1,1)
 			DeleteWorkspace("tmpgrad")
-			print(mag,magref,X0,Y0,gradX,gradY))
+			print(mag,magref,X0,Y0,gradX,gradY)
 			tt2.addRow((mag,magref,X0,Y0,gradX,gradY))
 AnalysisDataService.addOrReplace(matrixname,tt2)
 

--- a/muon/CommonBeamTuning.py
+++ b/muon/CommonBeamTuning.py
@@ -1,6 +1,7 @@
 """
 Scan a magnet, take data on three machines, analyse it, plot results
 """
+from __future__ import print_function
 
 # deal with Limits on Blocks. Does cset(block, value=too_large) raise an exception?
 
@@ -130,12 +131,12 @@ DPARS={} # how to analyse data
 DPARS["MUSR"]={"machine":"NDXMUSR","data":"//musr/data/musr%08d.nxs","tgbegin":0.5,"tgend":10.0,"p1begin":-0.23,"p1end":-0.1,"promptbegin":-0.4,"promptend":-0.3,"pulse":2}
 DPARS["EMU"]={"machine":"NDXEMU","data":"//emu/data/emu%08d.nxs","tgbegin":0.5,"tgend":10.0,"p1begin":0.1,"p1end":0.23,"promptbegin":-0.2,"promptend":0.0,"pulse":1}
 DPARS["HIFI"]={"machine":"NDXHIFI","data":"//hifi/data/hifi%08d.nxs","tgbegin":0.5,"tgend":10.0,"p1begin":0.1,"p1end":0.23,"promptbegin":-0.2,"promptend":0.0,"pulse":1}
-MACHINES0 = DPARS.keys()
+MACHINES0 = list(DPARS.keys())
 
 CPARS={} # how to get camera data
 CPARS["HIFI"]={"data":"//ndlt626/Users/Public/Documents/sxvh9usb/Test for Sept2016/IMG%d.fit","finder":getRecentFile,"processor":processHifiCam}
 #CPARS["MUSR"]={finder=TakeMusrPic,processor=processMusrCam} # filenames specified by user
-CAMERAS0=CPARS.keys()
+CAMERAS0=list(CPARS.keys())
 
 
 if(TESTMODE_DAQ is True):
@@ -152,30 +153,30 @@ if(TESTMODE_DAQ is True):
 			self.states[mac]="SETUP"
 			self.frames[mac]=0
 			self.runnums[mac]=self.startrunnums[mac]
-			print "registered "+str(mac)
+			print("registered "+str(mac))
 		def run_on_all(self,code,**kwds):
 			if(code=="get_run_state"):
 				return self.states
 			if(code=="begin"):
-				print "doing BEGIN, "+str(kwds)
-				for m in self.states.keys():
+				print("doing BEGIN, "+str(kwds))
+				for m in list(self.states.keys()):
 					self.states[m]="RUNNING"
 					self.frames[m]=0
 				if("waitfor_frames" in kwds):
-					print "waiting for frames="+str(kwds["waitfor_frames"])
+					print("waiting for frames="+str(kwds["waitfor_frames"]))
 					time.sleep(1)
-					for m in self.states.keys():
+					for m in list(self.states.keys()):
 						self.frames[m]=kwds["waitfor_frames"]+1
 			if(code=="get_run_number"):
 				return self.runnums
 			if(code=="end"):
-				print "ending runs"
-				for m in self.states.keys():
+				print("ending runs")
+				for m in list(self.states.keys()):
 					self.states[m]="SETUP"
 					self.runnums[m]+=1
 			if(code=="abort"):
-				print "aborting runs"
-				for m in self.states.keys():
+				print("aborting runs")
+				for m in list(self.states.keys()):
 					self.states[m]="SETUP"
 else:
 	from multiple_dae_controller import MultipleDaeController
@@ -187,15 +188,15 @@ if(TESTMODE_BLOCKS):
 		blockvals[BLOCKNAMES[b]]=50.0
 	def cset(block=None,value=None,wait=False,lowlimit=-99999.9,highlimit=99999.9,**args):
 		if(len(args)==1):
-			block=args.keys()[0]
-			value=args.values()[0]
-		print "setting "+str(block)+" to "+str(value)
+			block=list(args.keys())[0]
+			value=list(args.values())[0]
+		print("setting "+str(block)+" to "+str(value))
 		blockvals[block]=value
 		if(wait):
-			print "waiting for value to stabilise"
+			print("waiting for value to stabilise")
 			time.sleep(1)
 	def cshow(block):
-		print "CSHOW: "+str(blockvals[block])
+		print("CSHOW: "+str(blockvals[block]))
 		return None
 	def cget(block):
 		if block in blockvals:
@@ -203,7 +204,7 @@ if(TESTMODE_BLOCKS):
 		else:
 			return None
 	def waitfor_block(block,lowlimit=-99999.9,highlimit=99999.9):
-		print "waiting for "+block+" to stabilise"
+		print("waiting for "+block+" to stabilise")
 		time.sleep(1)
 else:
 	from genie_python.genie_startup import *
@@ -227,7 +228,7 @@ def cached_get_block(block):
 	# get value from table tt (_Reference) if supplied
 	# return cached value if all close
 	# or raise exception
-	print "doing cget("+block+")"
+	print("doing cget("+block+")")
 	rbk=cget(BLOCKNAMES[block])["value"]
 	ca=mtd[CACHENAME]
 	cnames=ca.column(0)
@@ -510,7 +511,7 @@ class ChooseBestValue(PythonAlgorithm):
 			rmax=0.0
 			for row in tab:
 				rates=[]
-				for (key,val) in row.items():
+				for (key,val) in list(row.items()):
 					if(key[-4:]=="Rate"):
 						rates.append(val)
 				rthis=sum(rates)
@@ -523,14 +524,14 @@ class ChooseBestValue(PythonAlgorithm):
 			refvals[mag0]=cached_get_block(mag0)
 		toSet=setTune(refvals,mag,x)
 		try:
-			for tsb,tsv in toSet.items():
+			for tsb,tsv in list(toSet.items()):
 				#print "doing cached_cset(",tsb,",",tsv,",wait=True)"
 				cached_cset(tsb,tsv,wait=True) # all at once with one "Wait"
 				#print "done the cached cset."
 			self.setProperty("BestValue",x)
 		except:
 			self.log().warning("Couldn't set one of the magnets, resetting all other values")
-			for tsb in toSet.keys():
+			for tsb in list(toSet.keys()):
 				tsv=refvals[tsb]
 				cached_cset(tsb,tsv,wait=True) # all at once with one "Wait"
 			self.setProperty("BestValue",-1000.0)
@@ -581,7 +582,7 @@ class ScanMagnet(PythonAlgorithm):
 		controller.run_on_all("set_waitfor_sleep_interval",5)
 		statuses=controller.run_on_all("get_run_state")
 		errstr=""
-		for m,status in statuses.items():
+		for m,status in list(statuses.items()):
 			if(status != "SETUP"):
 				errstr=errstr+" "+m+"="+status
 		if(errstr != ""):
@@ -602,7 +603,7 @@ class ScanMagnet(PythonAlgorithm):
 				toSet=setTune(refvals,Mag,x)
 				#for (mag,value) in toSet.items():
 				#	cset(mag,value,wait=True)
-				for tsb,tsv in toSet.items():
+				for tsb,tsv in list(toSet.items()):
 					self.log().notice("doing cached_cset("+str(tsb)+","+str(tsv)+")")
 					cached_cset(tsb,tsv,wait=True) # all at once with one "Wait"
 					#print "done cached cset."
@@ -618,7 +619,7 @@ class ScanMagnet(PythonAlgorithm):
 				controller.run_on_all("begin",waitfor_frames=frames) # assumes waits for this many frames to be reached on all before continuing
 				runs0=controller.run_on_all("get_run_number") # new method which will return a list of the run numbers in progress?
 				runs={}
-				for m,r in runs0.items():
+				for m,r in list(runs0.items()):
 					runs[m]=r[0] # real get_run_number returns tuple of number and an empty string!
 				self.log().notice("runs in progress are"+str(runs))
 				# ensure runs really have finished
@@ -628,7 +629,7 @@ class ScanMagnet(PythonAlgorithm):
 					finished=True
 					statuses=controller.run_on_all("get_run_state")
 					errstr=""
-					for m,status in statuses.items():
+					for m,status in list(statuses.items()):
 						if(status != "RUNNING"):
 							errstr=errstr+" "+m+"="+status
 					if(errstr != ""):
@@ -636,7 +637,7 @@ class ScanMagnet(PythonAlgorithm):
 						abandon=True # to get out of for() scan loop
 						break # out of while loop
 					allframes=controller.run_on_all("get_frames")
-					for m,ff in allframes.items():
+					for m,ff in list(allframes.items()):
 						self.log().notice(str(m)+" is at "+str(ff)+"frames out of "+str(frames))
 						if(ff<frames):
 							finished=False
@@ -659,7 +660,7 @@ class ScanMagnet(PythonAlgorithm):
 					cnums[i]=cs[0]
 				if(TESTMODE_DAQ=="abort"):
 					controller.run_on_all("abort") # end but don't fill the archive disks.
-					for mac in runs.keys():
+					for mac in list(runs.keys()):
 						runs[mac]-=1 # current run not saved, use the previous run instead!
 				else:
 					controller.run_on_all("end") # end and save them all.
@@ -670,7 +671,7 @@ class ScanMagnet(PythonAlgorithm):
 				Prog.report("Data collection")
 				tt.addRow([x]+runs2+cnums)
 
-		for tsb in toSet.keys():
+		for tsb in list(toSet.keys()):
 			tsv=refvals[tsb]
 			self.log().notice("doing cached_cset("+str(tsb)+","+str(tsv)+")")
 			cached_cset(tsb,tsv,wait=True) # all at once with one "Wait"

--- a/muon/CommonBeamTuningHifi.py
+++ b/muon/CommonBeamTuningHifi.py
@@ -1,6 +1,7 @@
 """
 Scan a magnet, take data on three machines, analyse it, plot results
 """
+from __future__ import print_function
 
 # HIFI only version! (for now)
 
@@ -108,7 +109,7 @@ def processHifiCam(filename):
 		(X0,Y0,XSig,YSig,Skew,Background,Intens,CostF2)=Params.column(1)
 		(eX0,eY0,eXSig,eYSig,eSkew,eBackground,eIntens,eCostF2)=Params.column(2)
 	except Exception as e:
-		print "error fitting or processing? ",e
+		print("error fitting or processing? ",e)
 		(X0,Y0,XSig,YSig,Skew,Background,Intens,CostF2)=[0.0]*8
 		(eX0,eY0,eXSig,eYSig,eSkew,eBackground,eIntens,eCostF2)=[0.0]*8
 		
@@ -140,12 +141,12 @@ DPARS={} # how to analyse data
 #DPARS["MUSR"]={"machine":"NDXMUSR","data":"//musr/data/musr%08d.nxs","tgbegin":0.5,"tgend":10.0,"p1begin":-0.23,"p1end":-0.1,"promptbegin":-0.4,"promptend":-0.3,"pulse":2}
 #DPARS["EMU"]={"machine":"NDXEMU","data":"//emu/data/emu%08d.nxs","tgbegin":0.5,"tgend":10.0,"p1begin":0.1,"p1end":0.23,"promptbegin":-0.2,"promptend":0.0,"pulse":1}
 DPARS["HIFI"]={"machine":"NDXHIFI","data":"//hifi/data/hifi%08d.nxs","tgbegin":0.5,"tgend":10.0,"p1begin":0.1,"p1end":0.23,"promptbegin":-0.2,"promptend":0.0,"pulse":1}
-MACHINES0 = DPARS.keys()
+MACHINES0 = list(DPARS.keys())
 
 CPARS={} # how to get camera data
 CPARS["HIFI"]={"data":"//ndlt626/Users/Public/Documents/sxvh9usb/HIFI Sept2018/IMG%d.fit","finder":getRecentFile,"processor":processHifiCam}
 #CPARS["MUSR"]={finder=TakeMusrPic,processor=processMusrCam} # filenames specified by user
-CAMERAS0=CPARS.keys()
+CAMERAS0=list(CPARS.keys())
 
 
 if(TESTMODE_DAQ is True):
@@ -162,30 +163,30 @@ if(TESTMODE_DAQ is True):
 			self.states[mac]="SETUP"
 			self.frames[mac]=0
 			self.runnums[mac]=self.startrunnums[mac]
-			print "registered "+str(mac)
+			print("registered "+str(mac))
 		def run_on_all(self,code,**kwds):
 			if(code=="get_run_state"):
 				return self.states
 			if(code=="begin"):
-				print "doing BEGIN, "+str(kwds)
-				for m in self.states.keys():
+				print("doing BEGIN, "+str(kwds))
+				for m in list(self.states.keys()):
 					self.states[m]="RUNNING"
 					self.frames[m]=0
 				if("waitfor_frames" in kwds):
-					print "waiting for frames="+str(kwds["waitfor_frames"])
+					print("waiting for frames="+str(kwds["waitfor_frames"]))
 					time.sleep(1)
-					for m in self.states.keys():
+					for m in list(self.states.keys()):
 						self.frames[m]=kwds["waitfor_frames"]+1
 			if(code=="get_run_number"):
 				return self.runnums
 			if(code=="end"):
-				print "ending runs"
-				for m in self.states.keys():
+				print("ending runs")
+				for m in list(self.states.keys()):
 					self.states[m]="SETUP"
 					self.runnums[m]+=1
 			if(code=="abort"):
-				print "aborting runs"
-				for m in self.states.keys():
+				print("aborting runs")
+				for m in list(self.states.keys()):
 					self.states[m]="SETUP"
 else:
 	from multiple_dae_controller import MultipleDaeController
@@ -197,15 +198,15 @@ if(TESTMODE_BLOCKS):
 		blockvals[BLOCKNAMES[b]]=50.0
 	def cset(block=None,value=None,wait=False,lowlimit=-99999.9,highlimit=99999.9,**args):
 		if(len(args)==1):
-			block=args.keys()[0]
-			value=args.values()[0]
-		print "setting "+str(block)+" to "+str(value)
+			block=list(args.keys())[0]
+			value=list(args.values())[0]
+		print("setting "+str(block)+" to "+str(value))
 		blockvals[block]=value
 		if(wait):
-			print "waiting for value to stabilise"
+			print("waiting for value to stabilise")
 			time.sleep(1)
 	def cshow(block):
-		print "CSHOW: "+str(blockvals[block])
+		print("CSHOW: "+str(blockvals[block]))
 		return None
 	def cget(block):
 		if block in blockvals:
@@ -213,7 +214,7 @@ if(TESTMODE_BLOCKS):
 		else:
 			return None
 	def waitfor_block(block,lowlimit=-99999.9,highlimit=99999.9):
-		print "waiting for "+block+" to stabilise"
+		print("waiting for "+block+" to stabilise")
 		time.sleep(1)
 else:
 	from genie_python.genie_startup import *
@@ -237,7 +238,7 @@ def cached_get_block(block):
 	# get value from table tt (_Reference) if supplied
 	# return cached value if all close
 	# or raise exception
-	print "doing cget("+block+")"
+	print("doing cget("+block+")")
 	rbk=cget(BLOCKNAMES[block])["value"]
 	ca=mtd[CACHENAME]
 	cnames=ca.column(0)
@@ -523,7 +524,7 @@ class ChooseBestValue(PythonAlgorithm):
 				rmax=0.0
 				for row in tab:
 					rates=[]
-					for (key,val) in row.items():
+					for (key,val) in list(row.items()):
 						if(key[-4:]=="Rate"):
 							rates.append(val)
 					rthis=sum(rates)
@@ -536,7 +537,7 @@ class ChooseBestValue(PythonAlgorithm):
 				for row in tab:
 					width=-1
 					height=-1
-					for (key,val) in row.items():
+					for (key,val) in list(row.items()):
 						if(key[-5:]=="Width"):
 							width=val
 						if(key[-6:]=="Height"):
@@ -551,14 +552,14 @@ class ChooseBestValue(PythonAlgorithm):
 			refvals[mag0]=cached_get_block(mag0)
 		toSet=setTune(refvals,mag,x)
 		try:
-			for tsb,tsv in toSet.items():
+			for tsb,tsv in list(toSet.items()):
 				#print "doing cached_cset(",tsb,",",tsv,",wait=True)"
 				cached_cset(tsb,tsv,wait=True) # all at once with one "Wait"
 				#print "done the cached cset."
 			self.setProperty("BestValue",x)
 		except:
 			self.log().warning("Couldn't set one of the magnets, resetting all other values")
-			for tsb in toSet.keys():
+			for tsb in list(toSet.keys()):
 				tsv=refvals[tsb]
 				cached_cset(tsb,tsv,wait=True) # all at once with one "Wait"
 			self.setProperty("BestValue",-1000.0)
@@ -609,7 +610,7 @@ class ScanMagnet(PythonAlgorithm):
 		controller.run_on_all("set_waitfor_sleep_interval",5)
 		statuses=controller.run_on_all("get_run_state")
 		errstr=""
-		for m,status in statuses.items():
+		for m,status in list(statuses.items()):
 			if(status != "SETUP"):
 				errstr=errstr+" "+m+"="+status
 		if(errstr != ""):
@@ -630,7 +631,7 @@ class ScanMagnet(PythonAlgorithm):
 				toSet=setTune(refvals,Mag,x)
 				#for (mag,value) in toSet.items():
 				#	cset(mag,value,wait=True)
-				for tsb,tsv in toSet.items():
+				for tsb,tsv in list(toSet.items()):
 					self.log().notice("doing cached_cset("+str(tsb)+","+str(tsv)+")")
 					cached_cset(tsb,tsv,wait=True) # all at once with one "Wait"
 					#print "done cached cset."
@@ -646,7 +647,7 @@ class ScanMagnet(PythonAlgorithm):
 				controller.run_on_all("begin",waitfor_frames=frames) # assumes waits for this many frames to be reached on all before continuing
 				runs0=controller.run_on_all("get_run_number") # new method which will return a list of the run numbers in progress?
 				runs={}
-				for m,r in runs0.items():
+				for m,r in list(runs0.items()):
 					runs[m]=r[0] # real get_run_number returns tuple of number and an empty string!
 				self.log().notice("runs in progress are"+str(runs))
 				# ensure runs really have finished
@@ -656,7 +657,7 @@ class ScanMagnet(PythonAlgorithm):
 					finished=True
 					statuses=controller.run_on_all("get_run_state")
 					errstr=""
-					for m,status in statuses.items():
+					for m,status in list(statuses.items()):
 						if(status != "RUNNING"):
 							errstr=errstr+" "+m+"="+status
 					if(errstr != ""):
@@ -664,7 +665,7 @@ class ScanMagnet(PythonAlgorithm):
 						abandon=True # to get out of for() scan loop
 						break # out of while loop
 					allframes=controller.run_on_all("get_frames")
-					for m,ff in allframes.items():
+					for m,ff in list(allframes.items()):
 						self.log().notice(str(m)+" is at "+str(ff)+"frames out of "+str(frames))
 						if(ff<frames):
 							finished=False
@@ -687,7 +688,7 @@ class ScanMagnet(PythonAlgorithm):
 					cnums[i]=cs[0]
 				if(TESTMODE_DAQ=="abort"):
 					controller.run_on_all("abort") # end but don't fill the archive disks.
-					for mac in runs.keys():
+					for mac in list(runs.keys()):
 						runs[mac]-=1 # current run not saved, use the previous run instead!
 				else:
 					controller.run_on_all("end") # end and save them all.
@@ -698,7 +699,7 @@ class ScanMagnet(PythonAlgorithm):
 				Prog.report("Data collection")
 				tt.addRow([x]+runs2+cnums)
 
-		for tsb in toSet.keys():
+		for tsb in list(toSet.keys()):
 			tsv=refvals[tsb]
 			self.log().notice("doing cached_cset("+str(tsb)+","+str(tsv)+")")
 			cached_cset(tsb,tsv,wait=True) # all at once with one "Wait"

--- a/muon/CopyLogsToHist7.py
+++ b/muon/CopyLogsToHist7.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 import datetime
 import math
@@ -41,7 +42,7 @@ class CopyLogsToHist(PythonAlgorithm):
 		ExtraLogs=self.getProperty("ExtraLogs").value
 		RunningOnly=self.getProperty("RunningOnly").value
 		LogNames.extend(ExtraLogs)
-		print "logs to be got: ",LogNames
+		print("logs to be got: ",LogNames)
 		#ws=self.getProperty("InputWS").value
 		file1=self.getProperty("FirstFile").value
 		file9=self.getProperty("LastFile").value
@@ -99,7 +100,7 @@ class CopyLogsToHist(PythonAlgorithm):
 				ws=wstuple[0] # plain run
 			prog_reporter.report("Loading")
 			if(gotToCurrentRun and int(ws.getRun().getProperty("run_number").value) != ff):
-				print "temporary file is for the previous run, probably no new one started"
+				print("temporary file is for the previous run, probably no new one started")
 				break
 			if(ff==firstnum):
 				#begin=datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_start").value,"%Y-%m-%dT%H:%M:%S")[0:6]))
@@ -120,13 +121,13 @@ class CopyLogsToHist(PythonAlgorithm):
 					times[ss]=numpy.append(times[ss],tconv[ri:])
 					temps[ss]=numpy.append(temps[ss],log.value[ri:])
 				except Exception as ee:
-					print ee
-					print "no log in this run for ",LogNames[ss]," inserting gap"
+					print(ee)
+					print("no log in this run for ",LogNames[ss]," inserting gap")
 					# one NaN point at the start of this run
 					tconv=numpy.array([(datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_start").value.strip(),"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds()])
 					times[ss]=numpy.append(times[ss],tconv)
 					temps[ss]=numpy.append(temps[ss],numpy.nan)
-			print "finished file ",thispath
+			print("finished file ",thispath)
 			if(gotToCurrentRun):
 				break
 		autoKC=self.getProperty("AutoConvKtoC").value
@@ -141,7 +142,7 @@ class CopyLogsToHist(PythonAlgorithm):
 			skip=1
 		else:
 			skip=2
-		print "time zero for result is ", begin
+		print("time zero for result is ", begin)
 		n=1
 		t0m= 100000000.0
 		t1m=-100000000.0
@@ -149,18 +150,18 @@ class CopyLogsToHist(PythonAlgorithm):
 			n=max(n,len(times[d]))
 			t0m=min(t0m,times[d][0])
 			t1m=max(t1m,times[d][-1])
-			print "detector ",2*d+1," has ",len(times[d])," time stamps and ",len(temps[d])," readings"
+			print("detector ",2*d+1," has ",len(times[d])," time stamps and ",len(temps[d])," readings")
 			if(len(times[d]) != len(temps[d]) ):
 				raise Exception("Something went wrong reading logs!")
-		print "longest log has ",n," points"
-		print "logs span ",(t1m-t0m)/3600.0," hours run time"
+		print("longest log has ",n," points")
+		print("logs span ",(t1m-t0m)/3600.0," hours run time")
 		interpflag = False
 		ipts=self.getProperty("InterpolatePts").value
 		if(ipts>1):
 			interpflag=True
 			interpdt=numpy.linspace(t0m/3600.0,t1m/3600.0,num=ipts)
 			n=len(interpdt)
-			print "interpolating into bins of width ",(interpdt[1]-interpdt[0])*3600.0," seconds"
+			print("interpolating into bins of width ",(interpdt[1]-interpdt[0])*3600.0," seconds")
 		else:
 			idelta=self.getProperty("InterpolateDelta").value
 			if(idelta>0):
@@ -168,7 +169,7 @@ class CopyLogsToHist(PythonAlgorithm):
 				t0m=math.ceil(t0m/idelta)*idelta # points are on round minute/hour boundaries where appropriate
 				interpdt=numpy.arange(t0m/3600.0,t1m/3600.0,idelta/3600.0)		
 				n=len(interpdt)
-				print "interpolating into ",n," bins"
+				print("interpolating into ",n," bins")
 		ows=WorkspaceFactory.create(ws,len(LogNames)*skip,n,n)
 		ows.setYUnitLabel("Temperature / K")
 		# ows.getAxis(0).setUnit("hours") would be nice...

--- a/muon/CopyLogsToHist8.py
+++ b/muon/CopyLogsToHist8.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 import datetime
 import math
@@ -108,7 +109,7 @@ class CopyLogsToHist(PythonAlgorithm):
 				ws=wstuple[0] # plain run
 			prog_reporter.report("Loading")
 			if(gotToCurrentRun and int(ws.getRun().getProperty("run_number").value) != ff):
-				print "temporary file is for the previous run, probably no new one started"
+				print("temporary file is for the previous run, probably no new one started")
 				break
 			if(ff==firstnum):
 				#begin=datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_start").value,"%Y-%m-%dT%H:%M:%S")[0:6]))
@@ -136,14 +137,14 @@ class CopyLogsToHist(PythonAlgorithm):
 					times[ss]=numpy.append(times[ss],tconv[ri:])
 					temps[ss]=numpy.append(temps[ss],log.value[ri:])
 				except Exception as ee:
-					print ee
-					print "no log in this run for ",LogNames[ss]," inserting gap"
+					print(ee)
+					print("no log in this run for ",LogNames[ss]," inserting gap")
 					# one NaN point at the start of this run
 					tconv=(mantid.kernel.DateAndTime(ws.getRun().getProperty("run_start").value.strip())-begin).total_seconds()
 					#tconv=numpy.array([(datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_start").value.strip(),"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds()])
 					times[ss]=numpy.append(times[ss],tconv)
 					temps[ss]=numpy.append(temps[ss],numpy.nan)
-			print "finished file ",thispath
+			print("finished file ",thispath)
 			if(gotToCurrentRun):
 				break
 		autoKC=self.getProperty("AutoConvKtoC").value
@@ -158,7 +159,7 @@ class CopyLogsToHist(PythonAlgorithm):
 			skip=32
 		else:
 			skip=0
-		print "time zero for result is ", begin
+		print("time zero for result is ", begin)
 		n=1
 		t0m= 100000000.0
 		t1m=-100000000.0
@@ -166,18 +167,18 @@ class CopyLogsToHist(PythonAlgorithm):
 			n=max(n,len(times[d]))
 			t0m=min(t0m,times[d][0])
 			t1m=max(t1m,times[d][-1])
-			print "log",LogNames[d]," has ",len(times[d])," time stamps and ",len(temps[d])," readings"
+			print("log",LogNames[d]," has ",len(times[d])," time stamps and ",len(temps[d])," readings")
 			if(len(times[d]) != len(temps[d]) ):
 				raise Exception("Something went wrong reading logs!")
-		print "longest log has ",n," points"
-		print "logs span ",(t1m-t0m)/3600.0," hours run time"
+		print("longest log has ",n," points")
+		print("logs span ",(t1m-t0m)/3600.0," hours run time")
 		interpflag = False
 		ipts=self.getProperty("InterpolatePts").value
 		if(ipts>1):
 			interpflag=True
 			interpdt=numpy.linspace(t0m/3600.0,t1m/3600.0,num=ipts)
 			n=len(interpdt)
-			print "interpolating into bins of width ",(interpdt[1]-interpdt[0])*3600.0," seconds"
+			print("interpolating into bins of width ",(interpdt[1]-interpdt[0])*3600.0," seconds")
 		else:
 			idelta=self.getProperty("InterpolateDelta").value
 			if(idelta>0):
@@ -185,7 +186,7 @@ class CopyLogsToHist(PythonAlgorithm):
 				t0m=math.ceil(t0m/idelta)*idelta # points are on round minute/hour boundaries where appropriate
 				interpdt=numpy.arange(t0m/3600.0,t1m/3600.0,idelta/3600.0)		
 				n=len(interpdt)
-				print "interpolating into ",n," bins"
+				print("interpolating into ",n," bins")
 		ows=WorkspaceFactory.create(ws,len(LogNames)+skip,n,n)
 		for d in range(0,len(LogNames)):
 			#log=ws.getRun().getLogData("DetectorTemp"+str(d+1))

--- a/muon/Create2DALCMap.py
+++ b/muon/Create2DALCMap.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.kernel import *
 from mantid.simpleapi import *
 #import math
@@ -66,7 +67,7 @@ class Create2DALCMap(PythonAlgorithm):
 				  except:
 					ylogval=float(ws.getRun().getProperty(logname).value)			  
 			  if(ylogval<=oldlogval and nmax>=1000000):
-				 print "Out of sequence run found, ending"
+				 print("Out of sequence run found, ending")
 				 oldlogval=10000001.0 # end now
 			  else:
 				  self.log().information(logname+"="+str(ylogval))
@@ -74,7 +75,7 @@ class Create2DALCMap(PythonAlgorithm):
 				  Rebunch(InputWorkspace='__ALCmap_raw',OutputWorkspace='__ALCmap_fine',NBunch=NBunch)
 				  AsymmetryCalc(InputWorkspace='__ALCmap_fine',OutputWorkspace='__ALCmap_asym',ForwardSpectra='1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32',BackwardSpectra='33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64',Alpha='1.0')
 				  ws=CropWorkspace(InputWorkspace='__ALCmap_asym',OutputWorkspace=wsname1,XMin=StartTime,XMax=EndTime)
-				  print logname+"="+str(ylogval)+" increment="+str(ylogval-oldlogval)
+				  print(logname+"="+str(ylogval)+" increment="+str(ylogval-oldlogval))
 				  oldlogval=ylogval
 				  filelist.append((ylogval,wsname1))
 				  vi=vi+1
@@ -82,9 +83,9 @@ class Create2DALCMap(PythonAlgorithm):
 				  DeleteWorkspace("__ALCmap_fine")
 				  DeleteWorkspace("__ALCmap_asym")
 		  except Exception as e:
-			  print e
-			  print e.__repr__()
-			  print "run out of data"
+			  print(e)
+			  print(e.__repr__())
+			  print("run out of data")
 			  oldlogval=10000001.0 # end now, run maybe not found?
 		  progRep.report()
 		# assemble conjoined run

--- a/muon/CreateFFTMapRF.py
+++ b/muon/CreateFFTMapRF.py
@@ -1,9 +1,9 @@
 # runlist=range(20764,20795)
-runlist=range(130292,130308)
+runlist=list(range(130292,130308))
 wksplist=''
 for run in (runlist):
 	Load(Filename='//hifi/data/hifi00'+str(run)+'.nxs',OutputWorkspace='raw')
-	AsymmetryCalc(InputWorkspace='raw',OutputWorkspace='asym',ForwardSpectra=range(3,17)+range(49,65),BackwardSpectra=range(17,49),Alpha='1.0')
+	AsymmetryCalc(InputWorkspace='raw',OutputWorkspace='asym',ForwardSpectra=list(range(3,17))+list(range(49,65)),BackwardSpectra=list(range(17,49)),Alpha='1.0')
 	CropWorkspace(InputWorkspace='asym',OutputWorkspace='trim',XMin=3.9,XMax=33.0)
 #	Rebunch(InputWorkspace='trim',OutputWorkspace='bunch',NBunch='5')
 	# c1=0.2276 usually

--- a/muon/DetectorRateTimeSeries.py
+++ b/muon/DetectorRateTimeSeries.py
@@ -3,6 +3,7 @@
 This algorithm calculates integrated counts for each spectrum (normalised per frame) from a range of files to be loaded and places into a single workspace. The "time" axis is now in clock time (hours from 00:00 on the day the first of the runs began) with the time between runs considered as belonging to the run just ended, apart from the last one.
 
 *WIKI*"""
+from __future__ import print_function
 
 import time
 import datetime
@@ -85,14 +86,14 @@ class DetectorRateTimeSeries(PythonAlgorithm):
 				thispath=file1[:j1]+"auto_A.tmp" # should really try all of them and pick newest!
 				wstuple=LoadMuonNexus(filename=thispath,OutputWorkspace="__CopyLogsTmp")
 				gotToCurrentRun=True
-			print len(wstuple)
+			print(len(wstuple))
 			if(len(wstuple)<=6):
 				ws=wstuple[0] # plain run
 			else:
 				ws=wstuple[5] # first period, should overlap with same log data in each
 			prog_reporter.report("Loading")
 			if(gotToCurrentRun and int(ws.getRun().getProperty("run_number").value) != ff):
-				print "temporary file is for the previous run, probably no new one started"
+				print("temporary file is for the previous run, probably no new one started")
 				break
 			if(ff==firstnum):
 				times=numpy.zeros(1)
@@ -120,12 +121,12 @@ class DetectorRateTimeSeries(PythonAlgorithm):
 				temps[ss]=numpy.append(temps[ss],ws2.readY(ss)[0]/ws.getRun().getProperty("goodfrm").value/bc)
 			times[-1]=((datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_start").value,"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds())/3600
 			times=numpy.append(times,((datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_end").value,"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds())/3600)
-			print "finished file ",thispath
+			print("finished file ",thispath)
 			DeleteWorkspace(ws2)
 			if(gotToCurrentRun):
 				break
-		print "time zero for result is ", begin
-		print "size might be X=",len(times)," and Y=",len(temps[0])
+		print("time zero for result is ", begin)
+		print("size might be X=",len(times)," and Y=",len(temps[0]))
 		ows=WorkspaceFactory.create(ws,NVectors=ws.getNumberHistograms(),XLength=len(times),YLength=len(temps[0]))
 		ows.setYUnitLabel("Counts per Frame")
 		# ows.getAxis(0).setUnit("hours") would be nice...

--- a/muon/DetectorRateTimeSeries2.py
+++ b/muon/DetectorRateTimeSeries2.py
@@ -3,6 +3,7 @@
 This algorithm calculates integrated counts for each spectrum (normalised per frame) from a range of files to be loaded and places into a single workspace. The "time" axis is now in clock time (hours from 00:00 on the day the first of the runs began) with the time between runs considered as belonging to the run just ended, apart from the last one.
 
 *WIKI*"""
+from __future__ import print_function
 
 import time
 import datetime
@@ -85,13 +86,13 @@ class DetectorRateTimeSeries(PythonAlgorithm):
 				thispath=file1[:j1]+"auto_A.tmp" # should really try all of them and pick newest!
 				wstuple=LoadMuonNexus(filename=thispath,OutputWorkspace="__CopyLogsTmp")
 				gotToCurrentRun=True
-			print len(wstuple)
+			print(len(wstuple))
 			ws=wstuple[0] # plain run
 			if isinstance(ws,mantid.api.WorkspaceGroup):
 				ws=ws[0] # first period, should overlap with same log data in each
 			prog_reporter.report("Loading")
 			if(gotToCurrentRun and int(ws.getRun().getProperty("run_number").value) != ff):
-				print "temporary file is for the previous run, probably no new one started"
+				print("temporary file is for the previous run, probably no new one started")
 				break
 			if(ff==firstnum):
 				times=numpy.zeros(1)
@@ -119,12 +120,12 @@ class DetectorRateTimeSeries(PythonAlgorithm):
 				temps[ss]=numpy.append(temps[ss],ws2.readY(ss)[0]/ws.getRun().getProperty("goodfrm").value/bc)
 			times[-1]=((datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_start").value,"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds())/3600
 			times=numpy.append(times,((datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_end").value,"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds())/3600)
-			print "finished file ",thispath
+			print("finished file ",thispath)
 			DeleteWorkspace(ws2)
 			if(gotToCurrentRun):
 				break
-		print "time zero for result is ", begin
-		print "size might be X=",len(times)," and Y=",len(temps[0])
+		print("time zero for result is ", begin)
+		print("size might be X=",len(times)," and Y=",len(temps[0]))
 		ows=WorkspaceFactory.create(ws,NVectors=ws.getNumberHistograms(),XLength=len(times),YLength=len(temps[0]))
 		ows.setYUnitLabel("Counts per Frame")
 		# ows.getAxis(0).setUnit("hours") would be nice...

--- a/muon/DoubleCountCorrelation.py
+++ b/muon/DoubleCountCorrelation.py
@@ -6,6 +6,7 @@ Optional offset to bin in S2 for delayed correlation
 Requires time bins to match across spectra (but doesn't check)
 Upgrade to Event Mode would be ideal here!
 if given Workspace Group then process all workspaces individually and sum results? or use MergeRuns on output WorkspaceGroup"""
+from __future__ import print_function
 import numpy
 
 from mantid.api import * # PythonAlgorithm, registerAlgorithm, WorkspaceProperty
@@ -32,7 +33,7 @@ class DoubleCountCorrelation(PythonAlgorithm):
 		Nspec=inWS.getNumberHistograms()
 		Xlen=len(inWS.readX(0))
 		Ylen=len(inWS.readY(0))
-		print "lengths ",Xlen,Ylen
+		print("lengths ",Xlen,Ylen)
 		
 		ows=WorkspaceFactory.create("Workspace2D",Nspec,Nspec+1,Nspec)
 		for j in range(Nspec):
@@ -40,15 +41,15 @@ class DoubleCountCorrelation(PythonAlgorithm):
 		#ows.replaceAxis(0,inWS.getAxis(1))
 		#ows.replaceAxis(1,inWS.getAxis(1))
 		ows.setYUnitLabel("Double Counts")
-		print inWS.dataX(0)
+		print(inWS.dataX(0))
 		i1=numpy.searchsorted(inWS.dataX(0),t1,side='left')
 		i2=numpy.searchsorted(inWS.dataX(0),t2,side='right')-1
-		print "requested bins [",i1,":",i2,"]"
+		print("requested bins [",i1,":",i2,"]")
 		if(i1+dt < 0):
 			i1=-dt
 		if(i2+dt > Ylen):
 			i2=Ylen-dt
-		print "processing bins [",i1,":",i2,"]"
+		print("processing bins [",i1,":",i2,"]")
 		if(i1<0 or i2<=i1 or i2>Ylen):
 			raise Exception("Oops, bin calculation mistake")
 		for s1 in range(Nspec):

--- a/muon/DoubleCountCorrelationSum2.py
+++ b/muon/DoubleCountCorrelationSum2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy
 """ For Dark Counts and other sparse runs 
 Correlates spectra looking for counts in S1 at time T1 and S2 at T2+dt
@@ -60,7 +61,7 @@ class DoubleCountCorrelationSum(PythonAlgorithm):
 			i1=-dtm
 		if(i2+dtm > Ylen):
 			i2=Ylen-dtm
-		print "processing bins [",i1,":",i2,"]"
+		print("processing bins [",i1,":",i2,"]")
 		if(i1<0 or i2<=i1 or i2>Ylen):
 			raise Exception("Oops, bin calculation mistake")
 		half=Nspec/2 # assume 2 banks

--- a/muon/FitIndividualPhases.py
+++ b/muon/FitIndividualPhases.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import math
 import numpy
 
@@ -25,7 +26,7 @@ class FitIndividualPhases(PythonAlgorithm):
         fsl=[]
         bsl=[]
         if gw.getNumberHistograms() != inputWS.getNumberHistograms():
-            print "oops, grouping for wrong instrument?"
+            print("oops, grouping for wrong instrument?")
         for i in range(gw.getNumberHistograms()):
             if gw.dataY(i)[0]==fgi:
                 fsl.append(gw.getDetector(i).getID())
@@ -59,9 +60,9 @@ class FitIndividualPhases(PythonAlgorithm):
             iv["p"+str(i)]=fr0.Function["p"+str(i)]
             iv["w"+str(i)]=fr0.Function["w"+str(i)]
             fittedw.append(fr0.Function["w"+str(i)])
-        for k in iv.keys():
+        for k in list(iv.keys()):
             if k[0]=="w":
-                print "fitted freq",iv[k],"or",iv[k]/2/math.pi/0.01355,"G with ampl=",iv["a"+k[1:]]
+                print("fitted freq",iv[k],"or",iv[k]/2/math.pi/0.01355,"G with ampl=",iv["a"+k[1:]])
 
         # bulk fit TF and re-generate workspace
         NS=inputWS.getNumberHistograms()
@@ -76,7 +77,7 @@ class FitIndividualPhases(PythonAlgorithm):
         for i in range(NS):
             t1bin=int(numpy.searchsorted(inputWS.dataX(i),t1))
             hs=numpy.sum(inputWS.dataY(i)[t1bin:])
-            print "histogram",i,"sum of good counts=",hs
+            print("histogram",i,"sum of good counts=",hs)
             if(hs>100):
                 dt=inputWS.dataX(i)[1]-inputWS.dataX(i)[0]
                 iv["n0"]=hs*dt/2.197*math.exp(t1/2.197)
@@ -97,11 +98,11 @@ class FitIndividualPhases(PythonAlgorithm):
                     outWS.dataE(i)[j*2]=ed["a"+str(j+1)]
                     outWS.dataY(i)[j*2+1]=p
                     outWS.dataE(i)[j*2+1]=ed["p"+str(j+1)]
-                outWS.dataX(i)[:]=range(2*NF+2)
+                outWS.dataX(i)[:]=list(range(2*NF+2))
                 outWS.dataY(i)[2*NF]=fr.Function["n0"]
                 outWS.dataE(i)[2*NF]=ed["n0"]
             else:
-                outWS.dataX(i)[:]=range(2*NF+2)
+                outWS.dataX(i)[:]=list(range(2*NF+2))
                 outWS.dataY(i)[:]=[0.0]*(2*NF+1)
                 empties.append(i)
                 
@@ -111,9 +112,9 @@ class FitIndividualPhases(PythonAlgorithm):
         if(empties):
             MaskDetectors(outWS,WorkspaceIndexList=empties)
         # summary
-        print "frequencies:"
+        print("frequencies:")
         for i in range(NF):
-            print FreqGuesses[i]," optimised to ",iv["w"+str(i+1)]," with amplitude",iv["a"+str(i+1)]
+            print(FreqGuesses[i]," optimised to ",iv["w"+str(i+1)]," with amplitude",iv["a"+str(i+1)])
         self.setProperty("OutputWorkspace",outWS)
         self.setProperty("FittedFrequencies",fittedw)
 

--- a/muon/FlattenAndFitCamera.py
+++ b/muon/FlattenAndFitCamera.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.api import *
 from mantid.kernel import *
 from mantid.simpleapi import *
@@ -33,10 +34,10 @@ class MaskAndFlattenCameraImage(PythonAlgorithm):
 			y2=iws.getNumberHistograms()
 
 		if(x1<0 or x2<=x1 or x2>len(iws.dataY(0))):
-			print "X1=",x1," X2=",x2," Xlimit=",len(iws.dataY(0))
+			print("X1=",x1," X2=",x2," Xlimit=",len(iws.dataY(0)))
 			raise Exception("X range error")
 		if(y1<0 or y2<=y1 or y2>iws.getNumberHistograms()):
-			print "Y1=",y1," Y2=",y2," Ylimit=",iws.getNumberHistograms()
+			print("Y1=",y1," Y2=",y2," Ylimit=",iws.getNumberHistograms())
 			raise Exception("Y range error")
 
 		ows=WorkspaceFactory.create("Workspace2D",NVectors=1,XLength=(x2-x1)*(y2-y1),YLength=(x2-x1)*(y2-y1))
@@ -73,7 +74,7 @@ class UnflattenCameraImage(PythonAlgorithm):
 		y2=((xy2-x2)/10000 ) + 1
 		x2=x2+1
 		if((x2-x1)*(y2-y1) != len(iws.dataX(spec))):
-			print "guessed x1=",x1," x2=",x2," y1=",y1," y2=",y2," length=", len(iws.dataX(spec))
+			print("guessed x1=",x1," x2=",x2," y1=",y1," y2=",y2," length=", len(iws.dataX(spec)))
 			raise Exception("Can't unflatten axes")
 		scale=self.getProperty("Scale").value
 
@@ -202,11 +203,11 @@ class DrawGaussianEllipse(PythonAlgorithm):
 			phi=math.pi/2.0+0.5*math.atan2(2*b,a-c) # math.cot**-1((a-c)/2/b)
 		
 		self.setProperty("MinorAxis",minor)
-		print "major axis length: ",major
+		print("major axis length: ",major)
 		self.setProperty("MajorAxis",major)
-		print "minor axis length: ",minor
+		print("minor axis length: ",minor)
 		self.setProperty("Rotation",phi)
-		print "rotation (degrees anticlockwise from x): ",phi*180.0/math.pi
+		print("rotation (degrees anticlockwise from x): ",phi*180.0/math.pi)
 		XM=major*math.cos(phi)
 		XL=-minor*math.sin(phi)
 		YM=major*math.sin(phi)

--- a/muon/LoadBeamCameraFile.py
+++ b/muon/LoadBeamCameraFile.py
@@ -3,6 +3,7 @@
 # optional filtering out of noise points (over specified delta from all 4 neighbours)
 # optional binning
 # set scale of image
+from __future__ import print_function
 from mantid.api import *
 from mantid.kernel import *
 from mantid.simpleapi import *
@@ -36,13 +37,13 @@ class LoadBeamCameraFile(PythonAlgorithm):
 			line=lines[80*(36-nbuf):80*(36-nbuf)+80]
 			nbuf=nbuf-1
 			if(line[0:3]=="END"):
-				print "found the end of the header"
+				print("found the end of the header")
 				break
 			if(line[0:6]=="NAXIS1"):
-				print "found axis1 line: ",line
+				print("found axis1 line: ",line)
 				width=int(line[9:30])
 			if(line[0:6]=="NAXIS2"):
-				print "found axis2 line: ",line
+				print("found axis2 line: ",line)
 				height=int(line[9:30])
 			if("DATE-OBS" in line):
 				datestr=line.split("'")[1]
@@ -51,9 +52,9 @@ class LoadBeamCameraFile(PythonAlgorithm):
 			if("EXPTIME" in line):
 				exposurelen=float(line[9:])
 			if('END' in line):
-				print "nearly got the end in [",line,"]"
+				print("nearly got the end in [",line,"]")
 
-		print "read ",nlr," potential header lines"
+		print("read ",nlr," potential header lines")
 		fh.seek(0,1) # back "here", flush read ahead buffers
 		if(height==0 or width==0):
 			raise Exception("Failed to identify image size")

--- a/muon/MaxEnt/MaxEnt.py
+++ b/muon/MaxEnt/MaxEnt.py
@@ -289,7 +289,7 @@ class MaxEnt(PythonAlgorithm):
         input_data = np.concatenate([input_data_ws.readY(i) for i in range(n_detectors)])
 
         groupings = [groupings_ws.readY(row)[0] for row in range(groupings_ws.getNumberHistograms())]
-        groupings = map(int, groupings)
+        groupings = list(map(int, groupings))
         n_groups = len(set(groupings))
 
         # Cleanup.
@@ -403,7 +403,7 @@ class MaxEnt(PythonAlgorithm):
                      "\nInput variables:\n"
 
         for type_map in self.int_vars, self.float_vars, self.bool_vars:
-            for name, value in type_map.items():
+            for name, value in list(type_map.items()):
                 log_output += str(name) + " = " + str(value) + "\n"
 
         Logger.get("MaxEnt").notice(log_output)
@@ -424,9 +424,9 @@ class MaxEnt(PythonAlgorithm):
         input_table = CreateEmptyTableWorkspace(OutputWorkspace = input_table_name)
         input_table.addColumn("str", "Name")
         input_table.addColumn("str", "Value")
-        inputs = itertools.chain(self.int_vars.items(), 
-                                 self.float_vars.items(),
-                                 self.bool_vars.items())
+        inputs = itertools.chain(list(self.int_vars.items()), 
+                                 list(self.float_vars.items()),
+                                 list(self.bool_vars.items()))
         for name, value in inputs:
             input_table.addRow([str(name), str(value)])
 
@@ -489,8 +489,8 @@ class MaxEnt(PythonAlgorithm):
             bool : self.bool_vars
         }
 
-        for var_type, var_map in type_map.items():
-            for name, value in var_map.items():
+        for var_type, var_map in list(type_map.items()):
+            for name, value in list(var_map.items()):
                 assert isinstance(value, var_type), (
                     "The variable '%s' is supposed to be of type %s but is of type %s."
                     % (name, str(var_type), str(type(value))))

--- a/muon/MaxEnt/grouping_file_converter.py
+++ b/muon/MaxEnt/grouping_file_converter.py
@@ -51,14 +51,14 @@ def convert_grouping_file(path, inst, description=None):
             groupings[group].add(detector)
 
         groupings_str = ""
-        for group, detectors in groupings.items():
+        for group, detectors in list(groupings.items()):
 
             groupings_str += "\n"
             groupings_str += GROUP_LINE % (str(group), 
                                            str(",".join(map(str,sorted(list(detectors))))))
 
         if description == None:
-            n_groups = sum([len(dets) for dets in groupings.values()])
+            n_groups = sum([len(dets) for dets in list(groupings.values())])
             description = "%s Grouping File for MaxEnt (%d Detectors)" % (inst, n_groups)
 
         return FILE_FORMAT % (__file__, inst, description, groupings_str)

--- a/muon/OpengenieMaxentTools/chosol.py
+++ b/muon/OpengenieMaxentTools/chosol.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import math
 # translation of chosol.for
@@ -107,26 +108,26 @@ if(__name__ == "__main__"):
 	b=np.array([2.5,1.2,4.8])
 
 	x1=CHOSOL0(a,b,3)
-	print np.linalg.cholesky(a)
+	print(np.linalg.cholesky(a))
 	x2=np.linalg.solve(a,b)
 	x3=CHOSOL(a,b)
-	print x1
-	print x2
-	print x3
-	print
+	print(x1)
+	print(x2)
+	print(x3)
+	print()
 
 	a1=np.array(a)
 	a2=np.array(a)
 	a1[0,2]=1.9
-	print "alter 0,2"
-	print a1
+	print("alter 0,2")
+	print(a1)
 	x11=CHOSOL0(a1,b,3)
-	print np.linalg.cholesky(a1)
-	print x11
-	print np.linalg.solve(a1,b)
+	print(np.linalg.cholesky(a1))
+	print(x11)
+	print(np.linalg.solve(a1,b))
 	a2[2,0]=1.9
-	print "alter 2,0"
+	print("alter 2,0")
 	x22=CHOSOL0(a2,b,3)
-	print np.linalg.cholesky(a2)
-	print x22
-	print np.linalg.solve(a2,b)
+	print(np.linalg.cholesky(a2))
+	print(x22)
+	print(np.linalg.solve(a2,b))

--- a/muon/OpengenieMaxentTools/fft.py
+++ b/muon/OpengenieMaxentTools/fft.py
@@ -1,4 +1,5 @@
 # translation of FFT.for
+from __future__ import print_function
 import math
 import numpy as np
 
@@ -67,7 +68,7 @@ def fortran_FFT(kk,a,sn):
 		k=kk-1 # orig, log2(something)
 		m=n2 # orig
 		if(i-j)<0: # both less 1
-			print "swapping",i," with ",j
+			print("swapping",i," with ",j)
 			b=a[j] # label 2
 			a[j]=a[i]
 			a[i]=b
@@ -113,15 +114,15 @@ def fortran_FFT(kk,a,sn):
 #arr=np.random.uniform(-1.0,1.0,size=16)+1.j*np.random.uniform(-1.0,1.0,size=16)
 arr=np.zeros([16],dtype=np.complex)
 arr[1]=complex(1.0,2.0)
-print arr
+print(arr)
 
 
 
 numpyfft=np.fft.ifft(arr)
 fortranfft=fortran_FFT(4,arr,1.0)
 for i in range(16):
-	print numpyfft[i]*16
-print fortranfft
+	print(numpyfft[i]*16)
+print(fortranfft)
 
 # above Python code not yet working
 # comparison between numpy and original FORTRAN running under Intel FORTRAN compiler:

--- a/muon/Quantum/Algorithms_Autoload/quantumtabledriven.py
+++ b/muon/Quantum/Algorithms_Autoload/quantumtabledriven.py
@@ -1,6 +1,7 @@
 ## Quantum - a program for solving spin evolution of the muon
 ## Author: James Lord
 ## Version 1.04, August 2018
+from __future__ import print_function
 import numpy
 import math
 #import time
@@ -70,7 +71,7 @@ def ParseTableWorkspaceToDict(tw,di0={}):
 	textlists=("measure","spins","detectspin","initialspin","tzero","recycle","brf","morespin","crystal","goniometer")
 	freetext=("fitfunction","loop0par","loop1par","fit0par","fit1par","fit2par","fit3par","fit4par","fit5par","fit6par","fit7par","fit8par","fit9par") # do not parse at all (are on one line)
 	di=dict(di0) # copy
-	text = zip(map(str,tw.column(0)),map(str,tw.column(1)))
+	text = list(zip(list(map(str,tw.column(0))),list(map(str,tw.column(1)))))
 	for (c1,c2) in text:
 		if(c1 != "" and c1[0] != "#"):
 			if(c1 in freetext):
@@ -79,7 +80,7 @@ def ParseTableWorkspaceToDict(tw,di0={}):
 				val=c2.split(",")
 				kvl0s=c1.split("(")[0]
 				if(kvl0s not in textlists):
-					val=map(float,val)
+					val=list(map(float,val))
 				di[c1]=val
 	return di
 
@@ -231,7 +232,7 @@ def RunModelledSystemCached(pars,key,cache={},counter=[0]):
 	else:
 		if(len(cache)>200):
 			# clear some cache entries, least recently used
-			stale=sorted(cache.items(),key=lambda x: x[1][1])
+			stale=sorted(list(cache.items()),key=lambda x: x[1][1])
 			for obsolete in stale[0:50]:
 				del cache[obsolete[0]]
 		ax,yb,eb=RunModelledSystem(pars,None)
@@ -1055,8 +1056,8 @@ class ReplaceFitParsInTable(PythonAlgorithm):
 		else:
 			# search for the first one with right set of keys
 			selGroup=None
-			for g in groupedNames.values():
-				print "examining param group ",g
+			for g in list(groupedNames.values()):
+				print("examining param group ",g)
 				if('P0' in g):
 					if(selGroup):
 						raise Exception("More than one possible Quantum function found - please specify")
@@ -1065,7 +1066,7 @@ class ReplaceFitParsInTable(PythonAlgorithm):
 			if(not(selGroup)):
 				raise Exception("Didn't find a Quantum fit function")
 		pardict={}
-		for (pnam,val) in selGroup.items():
+		for (pnam,val) in list(selGroup.items()):
 			if(pnam[0]=="P" and pnam[1].isdigit()):
 				if(pnam[2:7]=="plusP"):
 					pnum1=int(pnam[1])
@@ -1091,11 +1092,11 @@ class ReplaceFitParsInTable(PythonAlgorithm):
 		if(min(pardict.keys())==0 and max(pardict.keys())==len(pardict)-1):
 			# good, conv to list
 			fps=[float("NaN")]*len(pardict)
-			for (i,v) in pardict.items():
+			for (i,v) in list(pardict.items()):
 				fps[i]=v
 		else:
-			print pardict
-			print min(pardict.keys()),max(pardict.keys()),len(pardict)
+			print(pardict)
+			print(min(pardict.keys()),max(pardict.keys()),len(pardict))
 			raise Exception("Some parameters seem to be missing")
 		if(numpy.any(numpy.isnan(fps))):
 			raise Exception("A parameter is NaN - not updating the table")

--- a/muon/Quantum/Algorithms_Autoload/quantumtabletools.py
+++ b/muon/Quantum/Algorithms_Autoload/quantumtabletools.py
@@ -5,6 +5,7 @@
 #  Point by point fitting
 #  Crystal Fields
 #  Crystal space group symmetry and coordinates in fractions of unit cell
+from __future__ import print_function
 import numpy
 import math
 
@@ -42,18 +43,18 @@ def ParseStringToDict(st,di0={}):
 				for ss in sl.split(";"):
 					#print "processing ",ss
 					kvl=ss.split("=")
-					kvl=map(str.strip,kvl)
+					kvl=list(map(str.strip,kvl))
 					if(len(kvl)<2):
 						raise Exception("Bad line in model string")
 					val=kvl[-1].split(",")
 					kvl0s=kvl[0].split("(")[0]
 					if(kvl0s not in textlists):
 						#print "would like to float ",val," from ",sl
-						val=map(float,val)
+						val=list(map(float,val))
 					#print "value is ",val
 					for key in kvl[0:-1]:
 						if(key.find(".*")>=0):
-							for ek in di.keys():
+							for ek in list(di.keys()):
 								if( re.match(key,ek)):
 									di[ek]=val
 						else:
@@ -101,9 +102,9 @@ def EnumerateSites(p,d,keystr):
 	else:
 		d2=d
 		if(len(ds)==0):
-			ds=range(d)
+			ds=list(range(d))
 	if(len(ps)==0):
-		ps=range(p)
+		ps=list(range(p))
 	#print "ds=",ds,"ps=",ps
 	dps=[(pp*d2+dd) for pp in ps for dd in ds ]
 	return dps,kss
@@ -284,7 +285,7 @@ def ParseAndIterateModel(pars):
 	slices=1 # until requested
 
 	try:
-		slicetimes=map(float,pars["pulsed"])
+		slicetimes=list(map(float,pars["pulsed"]))
 		slices=len(slicetimes)+1
 		#print "sliced mode engaged, time boundaries are ",slicetimes
 	except:
@@ -335,7 +336,7 @@ def ParseAndIterateModel(pars):
 				labels[str(i)]=i
 			except:
 				element=baseatom.lstrip("0123456789")
-				ek={x.lstrip("0123456789") for x in PeriodicTable.keys()}
+				ek={x.lstrip("0123456789") for x in list(PeriodicTable.keys())}
 				if(baseatom in ek):
 					raise Exception("Atom "+atom+" has several isotopes, choose one")
 				elif(element in ek):
@@ -360,7 +361,7 @@ def ParseAndIterateModel(pars):
 	for i in range(dssize):
 		cfield[i]=[None]*len(labels)
 	# second loop to generate H(hyperfine)
-	for (key,val) in pars.items():
+	for (key,val) in list(pars.items()):
 		#print "2nd loop looking at ",key
 		# All have 1st arg @n for specific site or omitted if all or ignored if not dynamic
 		if(key[0:2]=="a("):
@@ -509,7 +510,7 @@ def ParseAndIterateModel(pars):
 	rfphaserand=[False]*slices
 	rrf=0 # numpy.zeros([slices],dtype=numpy.int)
 	iterator=iter(([0.0,0.0,1.0],)) # default zero field, one detector orientation along z
-	for (key,val) in pars.items():
+	for (key,val) in list(pars.items()):
 		if(key=="lfuniform"):
 			iterator=uniformLF(int(val[0]))
 		elif(key=="lfrandom"):
@@ -546,7 +547,7 @@ def ParseAndIterateModel(pars):
 						if(p[2]<0 or (p[2]==0 and (p[1]<0 or (p[1]==0 and p[0]<0)))):
 							p=(-p[0],-p[1],-p[2])
 						axset[p]=1
-			iterator=iter(axset.keys())
+			iterator=iter(list(axset.keys()))
 		elif(key=="tf"):
 			if(len(val)==6):
 				iterator=iter(((val[0:3],val[3:6],val[3:6],val[3:6]),)) # 2 * 3-vec: B, spin0
@@ -581,7 +582,7 @@ def ParseAndIterateModel(pars):
 				if(len(val)==1):
 					Bmag[i,:]=[float(val[0])/10000.0,0.0,0.0]
 				elif(len(val)==3):
-					Bmag[i,:]=map(lambda x: float(x)/10000.0,val)
+					Bmag[i,:]=[float(x)/10000.0 for x in val]
 				else:
 					raise Exception("bmagGauss should be a single number or a 3-vector")
 		elif(key[0:4]=="bmag"):
@@ -591,7 +592,7 @@ def ParseAndIterateModel(pars):
 				if(len(val)==1):
 					Bmag[i,:]=[float(val[0]),0.0,0.0]
 				elif(len(val)==3):
-					Bmag[i,:]=map(float,val)
+					Bmag[i,:]=list(map(float,val))
 				else:
 					raise Exception("bmag should be a single number or a 3-vector")
 		# RF mode
@@ -669,7 +670,7 @@ def ParseAndIterateModel(pars):
 		if(len(val)==3):
 			gonlist=(("y",val[0]),("z",val[1]),("y",val[2]))
 		else:
-			gonlist=zip(*[iter(val)]*2) # by twos
+			gonlist=list(zip(*[iter(val)]*2)) # by twos
 		gon=numpy.eye(3)
 		for r in gonlist:
 			c=math.cos(float(r[1])*math.pi/180.0)
@@ -737,7 +738,7 @@ def ParseAndIterateModel(pars):
 	# pre-check
 	if(dynstates>0):
 		if(not numpy.all(numpy.isfinite(pops))):
-			print "pops=",pops
+			print("pops=",pops)
 			raise Exception("Inf or NaN found in population array")
 		for i in range(dssize):
 			if(not numpy.all(numpy.isfinite(Hams[i]))):
@@ -802,7 +803,7 @@ def ParseAndIterateModel(pars):
 				else:
 					morespin=labels[morespinlist[0]]
 					try:
-						moreaxis=numpy.array(map(float,morespinlist[1:4]))*inverted
+						moreaxis=numpy.array(list(map(float,morespinlist[1:4])))*inverted
 						morespinlist=morespinlist[4:]
 					except:
 						if(morespinlist[1]=="beam"):
@@ -984,7 +985,7 @@ def processor_FittedCurve(pars,ybins,ebins,dest,asym):
 				if(matc2):
 					pff=pff[:matc2.start(2)]+str(fitstuff[3].column("Value")[i])+pff[matc2.end(2):]
 				else:
-					print "warning, couldn't find anywhere to recycle ",parname," into ",pff," using finder=",finder
+					print("warning, couldn't find anywhere to recycle ",parname," into ",pff," using finder=",finder)
 		nextpars={"fitfunction":pff}
 	else:
 		nextpars=None
@@ -999,7 +1000,7 @@ def tidyup_FittedCurve(pars,x0,x1):
 	try:
 		DeleteWorkspace(pars["tmpws"])
 	except:
-		print "workspace '",pars["tmpws"],"' won't die!!!"
+		print("workspace '",pars["tmpws"],"' won't die!!!")
 
 def processor_moments(pars,ybins,ebins,dest,bigomega,bigccos,bigcsin,numave):
 	# first or second moment, or amplitude, within freq range
@@ -1137,7 +1138,7 @@ def PreParseLoop(pars,hadaxis0,prog=None):
 					raise Exception("Too many nested loops")
 			lr=pars["loop"+str(loopctr)+"range"]
 			lpn=pars["loop"+str(loopctr)+"par"].split(";")
-			lpn=map(str.strip,lpn)
+			lpn=list(map(str.strip,lpn))
 			nv=len(lpn)
 			if(len(lr) != 2*nv+1):
 				raise Exception("mismatch between loop parameters and ranges")
@@ -1180,7 +1181,7 @@ def ParseMeasureType(pars,prog=None):
 				spGrp=SpaceGroupFactory.createSpaceGroup(sgtrans[sgname])
 			else:
 				raise ValueError("Space group "+vars[0]+" unknown")
-		unCell=UnitCell(*map(float,vars[1:]))
+		unCell=UnitCell(*list(map(float,vars[1:])))
 		if not (spGrp.isAllowedUnitCell(unCell)):
 			raise ValueError("Unit Cell and space group are incompatible")
 	else: # 1:1 scale, no symmetry. Dummy functions independent of Mantid
@@ -1273,7 +1274,7 @@ def ParseMeasureType(pars,prog=None):
 			pars["ntbins"]=(1,)
 		method=1
 		gen=ParseAndIterateModel(pars)
-		(spmat,ham,rho0,scint,rffrq,rrf,j1,j2,j3)=gen.next()
+		(spmat,ham,rho0,scint,rffrq,rrf,j1,j2,j3)=next(gen)
 		gen.close()
 		# (spmat,Hams1[0],rho0,scint,0.0,0,None,None,None)
 		nlevels=ham.shape[0]
@@ -1324,11 +1325,11 @@ def ParseMeasureType(pars,prog=None):
 		else: # uniformly distributed events over whole range
 			tmpws.dataE(0)[:]=4.0/numpy.sqrt(eevents*(timebins[1:]-timebins[:-1])/(timebins[-1]-timebins[0]))
 		if (numpy.any(numpy.isnan(tmpws.dataE(0)))):
-			print "E has at least one NaN"
-			print tmpws.dataE(0)[0],"...",tmpws.dataE(0)[-1]
+			print("E has at least one NaN")
+			print(tmpws.dataE(0)[0],"...",tmpws.dataE(0)[-1])
 		if (numpy.any(numpy.isinf(tmpws.dataE(0)))):
-			print "E has at least one Inf"
-			print tmpws.dataE(0)[0],"...",tmpws.dataE(0)[-1]
+			print("E has at least one Inf")
+			print(tmpws.dataE(0)[0],"...",tmpws.dataE(0)[-1])
 			
 	PreParseLoop(pars,hadaxis0,prog) # get axis lengths
 	
@@ -1339,7 +1340,7 @@ def ParseMeasureType(pars,prog=None):
 
 	if("selectorient" in pars["axis1name"]):
 		x1axis=[m[2] for m in pars["_crystalEqvs"]]
-		print "added names to axis1"
+		print("added names to axis1")
 
 	return (ybins,ebins,timebins,x0axis,x1axis,method,processor,tidyup)
 		
@@ -1434,7 +1435,7 @@ def RunModelledSystem(pars0,prog=None):
 		#print "pars to set for this iteration: ",loopvar
 		#print "pars0 insode loop: ",pars0
 		pars=pars0.copy()
-		for (k,v) in loopvar.items():
+		for (k,v) in list(loopvar.items()):
 			pars[k]=v
 		if(method==1):
 			bigomega=None # numpy.array([],dtype=numpy.float)
@@ -1530,7 +1531,7 @@ def RunModelledSystem(pars0,prog=None):
 			yvals=yvals/numave
 			recycle=processor(pars,ybins,ebins,dest,yvals)
 		if(recycle is not None):
-			for (k,v) in recycle.items():
+			for (k,v) in list(recycle.items()):
 				pars0[k]=v
 		if (prog is not None):
 			prog.report()

--- a/muon/Quantum/Algorithms_Autoload/quantumtools.py
+++ b/muon/Quantum/Algorithms_Autoload/quantumtools.py
@@ -1,6 +1,7 @@
 ## Module containing lower level functions for Quantum
 ## Author: James Lord
 ## Version 1.04, August 2018
+from __future__ import print_function
 import numpy
 import math
 #import time
@@ -68,7 +69,7 @@ def createSpinMat(spins):
 	if(N>100000):
 		raise Exception("Problem almost certainly too big to try")
 	if(N>1024):
-		print "fairly big problem, prepare for out of memory errors"
+		print("fairly big problem, prepare for out of memory errors")
 	# print ([Nsp,3]+spins+spins)
 	spmat=numpy.zeros((Nsp,3,N,N),dtype=complex)
 	# fill me (exact copy of Fortran QUANTUM including possible scale errors)
@@ -288,7 +289,7 @@ def BoltzmannDensityMatrix(Ham,kT,spin=None):
 		# subset indices (one state of spin):
 		subset=numpy.zeros([N2],dtype=int)
 		for k in range(N/m2):
-			subset[k*m1:(k+1)*m1]=range(k*m2,k*m2+m1,1)
+			subset[k*m1:(k+1)*m1]=list(range(k*m2,k*m2+m1,1))
 		#print "subset=",subset
 		newHam=numpy.zeros([N2,N2],dtype=complex)
 		for k in range(ns):
@@ -1078,10 +1079,10 @@ def getCrystalEquivalents(spGrp, unCell, refpt, allowInversion=True):
 		mats[i]=numpy.array((newX,newY,newZ))
 		if(numpy.allclose(mats[i],numpy.eye(3))):
 			transOps.append(op,) # translation
-			print "translation op",op.getIdentifier(),"with det=",numpy.linalg.det(mats[i])
+			print("translation op",op.getIdentifier(),"with det=",numpy.linalg.det(mats[i]))
 		if(numpy.allclose(mats[i],numpy.eye(3)*-1)):
 			transOps.append(op) # inversion (+ translation)
-			print "translation and inversion op",op.getIdentifier(),"with det=",numpy.linalg.det(mats[i])
+			print("translation and inversion op",op.getIdentifier(),"with det=",numpy.linalg.det(mats[i]))
 
 	for i,op in enumerate(ops):
 		if(op.getIdentifier() != 'x,y,z'):
@@ -1096,7 +1097,7 @@ def getCrystalEquivalents(spGrp, unCell, refpt, allowInversion=True):
 							old[3]=old[3]+" & "+op.getIdentifier()
 			if(uniq):
 				epts.append([newpt,mats[i],isinvop,op.getIdentifier()])
-				print "selected additional operation",op.getIdentifier(),"with det=",isinvop
+				print("selected additional operation",op.getIdentifier(),"with det=",isinvop)
 	
 	return [((m[1],False,m[3]) if numpy.linalg.det(m[1])>0 else (-m[1],True,"Inv "+m[3])) for m in epts]
 	
@@ -1533,8 +1534,8 @@ def solveRFDensityMat(Ham0,Ham1,Ham1i,omegaRF,start,detect,detecti,RRFharmonic,t
 	minamp=numpy.amin(ampls)
 	maxamp=numpy.amax(ampls)
 	if(minamp<0.999 or maxamp>1.001):
-		print "eigenvalues are not normalised? ts=",tslices," e=2**",eslices
-		print ampls
+		print("eigenvalues are not normalised? ts=",tslices," e=2**",eslices)
+		print(ampls)
 	# print "t=",tslices," e=2**",eslices," Egvals=",eval
 
 	# debug tests: eigenvectors should be orthogonal!

--- a/muon/Quantum/Examples/UnitTester.py
+++ b/muon/Quantum/Examples/UnitTester.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 # Quantum/Mantid regression tests!
 # set of source Tables, all called xxx_Tab.nxs
@@ -9,8 +10,8 @@ createMissing=False
 forceCreation=False # even if file exists and may be different!
 
 directory=os.path.dirname(__file__)
-print directory
-files=map(str.lower,os.listdir(directory))
+print(directory)
+files=list(map(str.lower,os.listdir(directory)))
 nsims=0
 nfits=0
 ncreations=0
@@ -21,7 +22,7 @@ for f in files:
 		r=f[:-8]+"_reference.nxs"
 		sw=f[:-8]+"_simulation"
 		if((r in files) or createMissing):
-			print "testing simulation ",fw
+			print("testing simulation ",fw)
 			LoadNexus(Filename=os.path.join(directory,f),OutputWorkspace=fw)
 			if(r in files):
 				LoadNexus(Filename=os.path.join(directory,r),OutputWorkspace=rw)
@@ -29,22 +30,22 @@ for f in files:
 			if(r in files):
 				cm=CompareWorkspaces(rw,sw,Tolerance=1.E-7,CheckSpectraMap=False)
 				if(cm[0]):
-					print "simulation output as expected"
+					print("simulation output as expected")
 					nsims=nsims+1
 				else:
 					for cmr in cm[1]:
-						print cmr
+						print(cmr)
 					if(not forceCreation):
 						raise Exception(fw+" ran, but output wrong")
 			if((forceCreation or not(r in files)) and createMissing):
 				SaveNexus(InputWorkspace=sw,Filename=os.path.join(directory,r))
-				print "created output for ",fw
+				print("created output for ",fw)
 				ncreations=ncreations+1
 			# Plot it (intelligent)
 			if(mtd[sw].getNumberHistograms()>5 and mtd[sw].getAxis(1).isNumeric()):
 				plot2D(sw)
 			else:
-				plotSpectrum(sw,range(mtd[sw].getNumberHistograms()))
+				plotSpectrum(sw,list(range(mtd[sw].getNumberHistograms())))
 
 # files for use as Fit Function
 # table xxx_Fn.nxs, fit real data xxx_Data.nxs (spectrum 0)
@@ -69,28 +70,28 @@ for f in files:
 			for row in mtd[ipw]:
 				Pars.append(row['Name'].split(".")[-1]+"="+str(row['Value']))
 			FnString="name=QuantumTableDrivenFunction"+str(len(Pars)-3)+","+",".join(Pars[:-1]) # note there's Scale and Baseline, and omit Cost Function
-			print "testing fit function from ",f," with ",len(Pars)-3," parameters"
+			print("testing fit function from ",f," with ",len(Pars)-3," parameters")
 			Fit(Function=FnString,InputWorkspace=dw,WorkspaceIndex=0,Output=bn,MaxIterations=0,CreateOutput=True)
 			RenameWorkspace(bn+"_Workspace",gw)
 			if(mtd[dw].getNumberHistograms() > 1):
 				cm=CompareWorkspaces(dw,gw,Tolerance=1.E-7,CheckSpectraMap=False)
 				if(cm[0]):
-					print "Fit ran, initial guess curve as expected"
+					print("Fit ran, initial guess curve as expected")
 					nfits=nfits+1
 				else:
 					for cmr in cm[1]:
-						print cmr
+						print(cmr)
 					if(not forceCreation):
 						raise Exception(f+" ran, but output wrong")
 			if((forceCreation or not(mtd[dw].getNumberHistograms() > 1)) and createMissing):
 				SaveNexus(InputWorkspace=gw,Filename=os.path.join(directory,d))
-				print "created output for ",f
+				print("created output for ",f)
 				ncreations=ncreations+1
 			# and now fit properly
 			Fit(Function=FnString,InputWorkspace=dw,WorkspaceIndex=0,Output=bn,CreateOutput=True)
 			# plot function and fit
 			plotSpectrum(ww,[0,1])
 
-print nsims," simulation and ",nfits," fit function tests successfully completed!"
+print(nsims," simulation and ",nfits," fit function tests successfully completed!")
 if(ncreations>0):
-	print ncreations," tests run for the firat time and results saved"
+	print(ncreations," tests run for the firat time and results saved")

--- a/muon/Quantum/Examples/standalone.py
+++ b/muon/Quantum/Examples/standalone.py
@@ -1,4 +1,5 @@
 # try Quantum without Mantid
+from __future__ import print_function
 from quantumtabletools import RunModelledSystem
 pars={
 	"spins":("Mu","e"),
@@ -13,4 +14,4 @@ x=q[0][0]
 y=q[1]
 e=q[2]
 for i in range(len(x)):
-	print x[i],y[0,i]
+	print(x[i],y[0,i])

--- a/muon/Quantum/Scripts/QuantumWizardScript.py
+++ b/muon/Quantum/Scripts/QuantumWizardScript.py
@@ -174,7 +174,7 @@ except:
 if(spins.count('') + ns != len(spins)):
 	raise Exception("Please don't leave gaps, I'm confused!")
 spins=spins[:ns]
-quadmap=map(lambda x: PeriodicTable[x][0]>2,spins)
+quadmap=[PeriodicTable[x][0]>2 for x in spins]
 # unique names for multiple identical nuclei
 for i in range(ns-1):
 	if spins[i] in spins[i+1:]:
@@ -404,7 +404,7 @@ for i in range(allowedLoops):
 		elif(lv=='Relaxation rate of Electron'):
 			pars["loop"+str(i)+"par"]="relax(e)"
 		elif(lv=='Conversion rates'):
-			keys=pars.keys()
+			keys=list(pars.keys())
 			for j in range(len(keys)):
 				if(keys[j][0:7]=="convert"):
 					pars["loop"+str(i)+"par"]=keys[j]
@@ -428,7 +428,7 @@ Table=CreateEmptyTableWorkspace()
 Table.addColumn("str","Code")
 Table.addColumn("str","Value")
 
-for (cod,valu) in pars.items():
+for (cod,valu) in list(pars.items()):
 	Table.addRow([cod,valu])
 
 for i in range(20):
@@ -443,7 +443,7 @@ nh=mtd["Results"].getNumberHistograms()
 if(nh ==1):
 	plotSpectrum("Results",0)
 elif(nh <= 5):
-	plotSpectrum("Results",range(nh))
+	plotSpectrum("Results",list(range(nh)))
 else:
 	plot2D("results")
 	

--- a/muon/SampleLogCountRateAnalyser4Emu.py
+++ b/muon/SampleLogCountRateAnalyser4Emu.py
@@ -7,6 +7,7 @@ Updated on 17 Jan. 2019, 22 Jan 2019
 Hint: just give run numbers first and try running the code.
 Sometimes date_time format needs a tweak.
 *WIKI*"""
+from __future__ import print_function
 
 import time
 import numpy as np
@@ -54,11 +55,11 @@ class GetPropertyFromRnum(object):
 		self.val13 = ws.run().getLogData("field_t20").value
 		# Get integrated count for each detector, and put them in a dictionary
 		self.dicsum = {}
-		for diclabel, data in ring_dic.items():
+		for diclabel, data in list(ring_dic.items()):
 			integrated_counts = []
 			for idx, ielem in enumerate(data):
 				integrated_counts.append(sum(ws.readY(ielem-1)))
-			self.dicsum[diclabel] = map(lambda x: int(x*nperiod), integrated_counts)
+			self.dicsum[diclabel] = [int(x*nperiod) for x in integrated_counts]
 
 # Table for detector array. This is for EMU
 ring_dic = {
@@ -84,7 +85,7 @@ log_table.addColumn("float", "T20")
 det_table = CreateEmptyTableWorkspace()
 det_table.setTitle("DetectorCountRates")
 det_table.addColumn("int", "RunNumber")
-for diclabel, data in ring_dic.items():
+for diclabel, data in list(ring_dic.items()):
     for idx, ielem in enumerate(data):
 		det_table.addColumn("float", "Det_"+str(ielem))
 # ***Ignore from here***
@@ -104,25 +105,25 @@ for n in range(rnum_start,rnum_end + 1):
 		time0 = time.mktime(time.strptime(logdat.val1,"%Y-%m-%dT%H:%M:%S")) # Calculates absolute time in s for time when run started
 		
 		# Number of frames
-		date_time_array = map(str,np.array(logdat.val2))
+		date_time_array = list(map(str,np.array(logdat.val2)))
 		relative_times = [] # Makes a list of times (in absolute time) for the logged value.
 		for date_time in date_time_array:
 			relative_times.append(time.mktime(time.strptime(date_time,format_paramlog)) - time0 - adjust)
-		frames_array = map(float,np.array(logdat.val3))
+		frames_array = list(map(float,np.array(logdat.val3)))
 		number_of_frames = frames_array[np.argmax(relative_times)] # Take the largest time for the final value
 		# Total counts from Beamlog_Total_Counts
-		date_time_array = map(str,np.array(logdat.val4))
+		date_time_array = list(map(str,np.array(logdat.val4)))
 		relative_times = []
 		for date_time in date_time_array:
 			relative_times.append(time.mktime(time.strptime(date_time,format_paramlog)) - time0 - adjust)
-		total_counts_array = map(float,np.array(logdat.val5))
+		total_counts_array = list(map(float,np.array(logdat.val5)))
 		total_counts = total_counts_array[np.argmax(relative_times)]
 		# Slits
-		date_time_array = map(str,np.array(logdat.val6))
+		date_time_array = list(map(str,np.array(logdat.val6)))
 		relative_times = []
 		for date_time in date_time_array:
 			relative_times.append(time.mktime(time.strptime(date_time,format_paramlog)) - time0 - adjust)
-		slits_array = map(float,np.array(logdat.val7))
+		slits_array = list(map(float,np.array(logdat.val7)))
 		relative_times_reduced = [] # Interested only in times (absolute time) after the start of run. Trims tables for time and log value
 		slits_array_reduced = []
 		for idx, ielem in enumerate(relative_times):
@@ -132,11 +133,11 @@ for n in range(rnum_start,rnum_end + 1):
 		w = np.diff(relative_times_reduced, n=1)	# Parameters are recorded only when there is a change
 		slits_avg = np.average(slits_array_reduced[:-1], weights = w) # Takes weighted average
 		# TS1 current
-		date_time_array = map(str,np.array(logdat.val8))
+		date_time_array = list(map(str,np.array(logdat.val8)))
 		relative_times = []
 		for date_time in date_time_array:
 			relative_times.append(time.mktime(time.strptime(date_time,format_paramlog)) - time0 - adjust)
-		ts1_current_array = map(float,np.array(logdat.val9))
+		ts1_current_array = list(map(float,np.array(logdat.val9)))
 		relative_times_reduced = []
 		ts1_current_array_reduced = []
 		for idx, ielem in enumerate(relative_times):
@@ -146,11 +147,11 @@ for n in range(rnum_start,rnum_end + 1):
 		w = np.diff(relative_times_reduced, n=1)	
 		ts1_current = np.average(ts1_current_array_reduced[:-1], weights = w)
 		# LF field
-		date_time_array = map(str,np.array(logdat.val10))
+		date_time_array = list(map(str,np.array(logdat.val10)))
 		relative_times = []
 		for date_time in date_time_array:
 			relative_times.append(time.mktime(time.strptime(date_time,format_paramlog)) - time0 - adjust)
-		field_array = map(float,np.array(logdat.val11))
+		field_array = list(map(float,np.array(logdat.val11)))
 		relative_times_reduced = []
 		field_array_reduced = []
 		for idx, ielem in enumerate(relative_times):
@@ -160,11 +161,11 @@ for n in range(rnum_start,rnum_end + 1):
 		w = np.diff(relative_times_reduced, n=1)	
 		field = np.average(field_array_reduced[:-1], weights = w)
 		# TF field
-		date_time_array = map(str,np.array(logdat.val12))
+		date_time_array = list(map(str,np.array(logdat.val12)))
 		relative_times = []
 		for date_time in date_time_array:
 			relative_times.append(time.mktime(time.strptime(date_time,format_paramlog)) - time0 - adjust)
-		t20_array = map(float,np.array(logdat.val13))
+		t20_array = list(map(float,np.array(logdat.val13)))
 		relative_times_reduced = []
 		t20_array_reduced = []
 		for idx, ielem in enumerate(relative_times):
@@ -179,15 +180,15 @@ for n in range(rnum_start,rnum_end + 1):
 		# Integrated count for each detector. Normalised to frame. Add it in the table for count rate
 		rnum_detcounts = [n]
 		for diclabel in ring_dic:
-			rnum_detcounts = rnum_detcounts + map(lambda x: x/number_of_frames, logdat.dicsum[diclabel])
+			rnum_detcounts = rnum_detcounts + [x/number_of_frames for x in logdat.dicsum[diclabel]]
 		det_table.addRow(rnum_detcounts)
 
-		print("Run ",n," processed")
+		print(("Run ",n," processed"))
 	except Exception as e:
-		print("Run ",n," was not processed")
-		print '===Error==='
-		print 'type:' + str(type(e))
-		print 'args:' + str(e.args)
-		print 'message:' + e.message
-		print 'e itself:' + str(e)
+		print(("Run ",n," was not processed"))
+		print('===Error===')
+		print('type:' + str(type(e)))
+		print('args:' + str(e.args))
+		print('message:' + e.message)
+		print('e itself:' + str(e))
 		

--- a/muon/SampleLogCountRateAnalyser4Emu.py
+++ b/muon/SampleLogCountRateAnalyser4Emu.py
@@ -183,9 +183,9 @@ for n in range(rnum_start,rnum_end + 1):
 			rnum_detcounts = rnum_detcounts + [x/number_of_frames for x in logdat.dicsum[diclabel]]
 		det_table.addRow(rnum_detcounts)
 
-		print("Run ",n," processed"))
+		print("Run ",n," processed")
 	except Exception as e:
-		print("Run ",n," was not processed"))
+		print("Run ",n," was not processed")
 		print('===Error===')
 		print('type:' + str(type(e)))
 		print('args:' + str(e.args))

--- a/muon/SampleLogCountRateAnalyser4Emu.py
+++ b/muon/SampleLogCountRateAnalyser4Emu.py
@@ -183,9 +183,9 @@ for n in range(rnum_start,rnum_end + 1):
 			rnum_detcounts = rnum_detcounts + [x/number_of_frames for x in logdat.dicsum[diclabel]]
 		det_table.addRow(rnum_detcounts)
 
-		print(("Run ",n," processed"))
+		print("Run ",n," processed"))
 	except Exception as e:
-		print(("Run ",n," was not processed"))
+		print("Run ",n," was not processed"))
 		print('===Error===')
 		print('type:' + str(type(e)))
 		print('args:' + str(e.args))

--- a/muon/SimulateMuonTFData.py
+++ b/muon/SimulateMuonTFData.py
@@ -197,14 +197,14 @@ class SetupSimInstrument(PythonAlgorithm):
 			axnames={"+x":"1,0,0","+y":"0,1,0","+z":"0,0,1","-x":"-1,0,0","-y":"0,-1,0","-z":"0,0,-1"}
 			if(ax in axnames):
 				ax=axnames[ax]
-			axvec=V3D(*map(float,ax.split(",")))
+			axvec=V3D(*list(map(float,ax.split(","))))
 		axvec=axvec*(1.0/axvec.norm())
 
 		if not self.getProperty("MuonSpin").isDefault:
 			id=self.getProperty("MuonSpin").value
 			if(id in axnames):
 				id=axnames[id]
-			idvec=V3D(*map(float,id.split(",")))
+			idvec=V3D(*list(map(float,id.split(","))))
 		idvec=idvec*(1.0/idvec.norm())
 		
 		nr=dws.getNumberHistograms()
@@ -283,7 +283,7 @@ class SimulateMuonTFData(PythonAlgorithm):
 	def PyExec(self):
 		# get stuff
 		tab=self.getProperty('InstrumentSetupTable').value
-		inst=tab.keys()[0]
+		inst=list(tab.keys())[0]
 		orient=None
 		if "_" in inst:
 			(inst1,orient)=inst.split("_")

--- a/muon/SplitLaserPowerLog.py
+++ b/muon/SplitLaserPowerLog.py
@@ -33,7 +33,7 @@ class SplitLaserPowerLog(PythonAlgorithm):
 		with open(pl,"r") as file:
 			for line in file:
 				if (doneHeader):
-					(t,p)=map(float,line.split())
+					(t,p)=list(map(float,line.split()))
 					timestamps.append(t)
 					powers.append(p)
 				else:

--- a/muon/muesr/examples/Fe_bcc/run_example.py
+++ b/muon/muesr/examples/Fe_bcc/run_example.py
@@ -1,5 +1,4 @@
 #   This is an example to calculate the muon local field at the tetrahedral site(s) in bcc-Fe.
-from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import os

--- a/muon/muesr/examples/Fe_bcc/run_example.py
+++ b/muon/muesr/examples/Fe_bcc/run_example.py
@@ -1,4 +1,5 @@
 #   This is an example to calculate the muon local field at the tetrahedral site(s) in bcc-Fe.
+from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import os

--- a/muon/muesr/examples/LaFeAsO/run_example.py
+++ b/muon/muesr/examples/LaFeAsO/run_example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import os
 import glob

--- a/muon/muesr/examples/LaFeAsO/run_example.py
+++ b/muon/muesr/examples/LaFeAsO/run_example.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import os
 import glob

--- a/muon/muesr/examples/LiFePO4/run_example.py
+++ b/muon/muesr/examples/LiFePO4/run_example.py
@@ -4,6 +4,7 @@ the results of Ref. PhysRevB.84.054430. The description of the magnetic order
 will be done first using the helper function which facilitate the user input
 and then programmatically.
 """
+from __future__ import print_function
 
 # This needs an interactive python sessionn, which is not currently supported in Mantid
 

--- a/muon/muesr/examples/LiFePO4/run_example.py
+++ b/muon/muesr/examples/LiFePO4/run_example.py
@@ -4,7 +4,6 @@ the results of Ref. PhysRevB.84.054430. The description of the magnetic order
 will be done first using the helper function which facilitate the user input
 and then programmatically.
 """
-from __future__ import print_function
 
 # This needs an interactive python sessionn, which is not currently supported in Mantid
 

--- a/muon/muesr/examples/MnSi/run_example.py
+++ b/muon/muesr/examples/MnSi/run_example.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import os          # join path on windows.  
 import numpy as np

--- a/muon/muesr/examples/MnSi/run_example.py
+++ b/muon/muesr/examples/MnSi/run_example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import os          # join path on windows.  
 import numpy as np

--- a/muon/muesr/examples/test/example.py
+++ b/muon/muesr/examples/test/example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import os
 import numpy as np

--- a/muon/muesr/examples/test/example.py
+++ b/muon/muesr/examples/test/example.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import os
 import numpy as np

--- a/muon/muesr/install_script.py
+++ b/muon/muesr/install_script.py
@@ -2,8 +2,8 @@
 from __future__ import print_function
 import subprocess
 # install phase
-print((subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
-print((subprocess.Popen("python -m pip install --user --upgrade mulfc muesr",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
+print(subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
+print(subprocess.Popen("python -m pip install --user --upgrade mulfc muesr",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
 
 # use phase
 import sys, site

--- a/muon/muesr/install_script.py
+++ b/muon/muesr/install_script.py
@@ -1,8 +1,9 @@
 # === This works inside the MantiPlot shell on Win 7 ===
+from __future__ import print_function
 import subprocess
 # install phase
-print(subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate())
-print(subprocess.Popen("python -m pip install --user --upgrade mulfc muesr",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate())
+print((subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
+print((subprocess.Popen("python -m pip install --user --upgrade mulfc muesr",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
 
 # use phase
 import sys, site

--- a/muon/muesr/school/CoF2/run_example.py
+++ b/muon/muesr/school/CoF2/run_example.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import os

--- a/muon/muesr/school/CoF2/run_example.py
+++ b/muon/muesr/school/CoF2/run_example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import os

--- a/muon/muesr/school/La2CuO4/run_example.py
+++ b/muon/muesr/school/La2CuO4/run_example.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import os

--- a/muon/muesr/school/La2CuO4/run_example.py
+++ b/muon/muesr/school/La2CuO4/run_example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import os

--- a/muon/muesr/script_update.py
+++ b/muon/muesr/script_update.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
 import subprocess
 # install phase
-print(subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
-print(subprocess.Popen("python -m pip install --upgrade --user https://github.com/bonfus/muesr/archive/newcif.zip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()
+print(subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate())
+print(subprocess.Popen("python -m pip install --upgrade --user https://github.com/bonfus/muesr/archive/newcif.zip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate())

--- a/muon/muesr/script_update.py
+++ b/muon/muesr/script_update.py
@@ -1,4 +1,5 @@
+from __future__ import print_function
 import subprocess
 # install phase
-print(subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate())
-print(subprocess.Popen("python -m pip install --upgrade --user https://github.com/bonfus/muesr/archive/newcif.zip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate())
+print((subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
+print((subprocess.Popen("python -m pip install --upgrade --user https://github.com/bonfus/muesr/archive/newcif.zip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))

--- a/muon/muesr/script_update.py
+++ b/muon/muesr/script_update.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
 import subprocess
 # install phase
-print((subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
-print((subprocess.Popen("python -m pip install --upgrade --user https://github.com/bonfus/muesr/archive/newcif.zip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
+print(subprocess.Popen("python -m pip install --upgrade pip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
+print(subprocess.Popen("python -m pip install --upgrade --user https://github.com/bonfus/muesr/archive/newcif.zip",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()

--- a/reflectometry/experimental/algorithms/Stitch1D.py
+++ b/reflectometry/experimental/algorithms/Stitch1D.py
@@ -6,6 +6,7 @@ are not provided, then these are taken to be the region of x-axis intersection.
 
 The workspaces must be histogrammed. Use [[ConvertToHistogram]] on workspaces prior to passing them to this algorithm.
 *WIKI*"""
+from __future__ import print_function
 from mantid.simpleapi import *
 
 from mantid.api import *
@@ -61,7 +62,7 @@ class Stitch1D(PythonAlgorithm):
             alg.setPropertyValue("OutputWorkspace","UNUSED_NAME_FOR_CHILD")
         
         alg.setRethrows(True)
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             alg.setProperty(key, value)
         
         alg.execute()
@@ -134,7 +135,7 @@ class Stitch1D(PythonAlgorithm):
         outScaleFactor = self.getProperty('OutScaleFactor').value
         
         params = self.__create_rebin_parameters()
-        print params
+        print(params)
         lhs_rebinned = self.__run_as_child("Rebin", InputWorkspace=self.getProperty("LHSWorkspace").value, Params=params)
         rhs_rebinned = self.__run_as_child("Rebin", InputWorkspace=self.getProperty("RHSWorkspace").value, Params=params)
         

--- a/reflectometry/offspec/offspec.py
+++ b/reflectometry/offspec/offspec.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from math import *
 from mantid.simpleapi import *
 from mantid.api import WorkspaceGroup
@@ -26,7 +27,7 @@ class LinearDetector():
         self.pixelsize = pixelsize
         self.centrespectrum = self.nspec/2.0+self.minspec
         try:
-            self.nbackgroundspectra = len(range(self.btm_background))+len(range(self.top_background))
+            self.nbackgroundspectra = len(list(range(self.btm_background)))+len(list(range(self.top_background)))
         except: pass
     def croptodetector(self, inputworkspace, suffix = 'det'):
         CropWorkspace(InputWorkspace=inputworkspace,OutputWorkspace=inputworkspace+suffix,StartWorkspaceIndex=self.minspec-1,EndWorkspaceIndex=self.maxspec-1)
@@ -168,13 +169,13 @@ def parseRunList(istring):
                         tstr[j].strip()
                         tstr2=tstr[j].split('-')
                         tstr3=tstr2[1].split(':')
-                        r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+                        r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
                         for k in r1:
                             rlist2.append(str(k))
                     elif tstr[j].find('-') >=0:
                         tstr[j].strip()
                         tstr2=tstr[j].split('-')
-                        r1=range(int(tstr2[0]),int(tstr2[1])+1)
+                        r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
                         for k in r1:
                             rlist2.append(str(k))
                     else:
@@ -184,13 +185,13 @@ def parseRunList(istring):
                     rlist1[i].strip()
                     tstr2=rlist1[i].split('-')
                     tstr3=tstr2[1].split(':')
-                    r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+                    r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
                     for k in r1:
                         rlist2.append(str(k))
                 elif rlist1[i].find('-')>=0:
                     rlist1[i].strip()
                     tstr2=rlist1[i].split('-')
-                    r1=range(int(tstr2[0]),int(tstr2[1])+1)
+                    r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
                     for k in r1:
                         rlist2.append(str(k))
                 else:
@@ -224,13 +225,13 @@ def floodnorm(wkspName,floodfile='',floodopt='default'):
    else:
       flood_file = floodfile
    
-   print "using flood normalisation file "+flood_file
+   print("using flood normalisation file "+flood_file)
     
    flood_wksp = current_detector.nickname + "_flood"
    if  flood_wksp not in mtd:
        LoadNexusProcessed(Filename=flood_file,OutputWorkspace=flood_wksp)
        if current_detector.idf:
-        print "change idf"
+        print("change idf")
         LoadInstrument(flood_wksp, Filename = current_detector.idf)
        ConvertUnits(flood_wksp, Target='Wavelength', OutputWorkspace =  flood_wksp)
         
@@ -362,7 +363,7 @@ def nrtestfn(runlist,wnames):
 def removeoutlayer(wksp):
     ''' remove counts from bins where there are so few counts it makes a mess of the polarisation
     calculation'''
-    print "removeoutlayer called"
+    print("removeoutlayer called")
     a1=mtd[wksp]
     nspec=a1.getNumberHistograms()
     x=a1.readX(0)
@@ -592,9 +593,9 @@ def nrCalcSEConst(RFFrequency,poleShoeAngle):
         B=34.288
     else:
         #B=2.0*34.288
-        print "\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
-        print "STOP IT!!!  You will NOT run the RF system above 1 MHz!"
-        print "\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+        print("\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+        print("STOP IT!!!  You will NOT run the RF system above 1 MHz!")
+        print("\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
         raise Exception("Spin Echo breaking attempt")
     h=6.62607e-34
     m=1.67493e-27
@@ -607,7 +608,7 @@ def nrCalcSEConst(RFFrequency,poleShoeAngle):
     th0=float(poleShoeAngle)
     th0=-0.0000000467796*(th0**5)+0.0000195413*(th0**4)-0.00326229*(th0**3)+0.271767*(th0**2)-10.4269*th0+198.108
     c1=Gl*m*2.0*B*L/(2.0*pi*h*tan(th0*pi/180.0)*1.0e20)
-    print "10A: "+str(c1*1e8)+", 4A: "+str(c1*1e8*4**2/100)
+    print("10A: "+str(c1*1e8)+", 4A: "+str(c1*1e8*4**2/100))
     return c1*1e8
     
 def plotSEconst(RFFrequency):
@@ -615,7 +616,7 @@ def plotSEconst(RFFrequency):
     poleshoestopangle = 90.0
     rffrequency = str(RFFrequency)
     angles = np.linspace(poleshoestartangle,poleshoestopangle, 100)
-    print angles
+    print(angles)
     SEC10 = [nrCalcSEConst(rffrequency, x) for x in angles]
     SEC4 = [y*4**2/10**2 for y in SEC10]
     
@@ -714,7 +715,7 @@ def nrSERGISFn(runList,nameList,P0runList,P0nameList,incidentAngles,SEConstants,
                 a1=2.0*float(incAngles[k])+atan((float(minSpec)-float(specChan))*current_detector.pixelsize/3.63)*180.0/pi
                 #print str(2.0*float(incAngles[k]))+" "+str(atan((float(minSpec)-float(specChan))*1.2e-3/3.63)*180.0/pi)+" "+str(a1)
                 RotateInstrumentComponent(wksp+"det","DetectorBench",X="-1.0",Angle=str(a1))
-                GroupDetectors(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+                GroupDetectors(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
                 Divide(LHSWorkspace=wksp+"sum",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"norm")
                 Divide(LHSWorkspace=wksp+"det",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"detnorm")
                 floodnorm(wksp+"detnorm",floodopt=dofloodnorm)
@@ -849,8 +850,8 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
             RotateInstrumentComponent(i+"det","DetectorBench",X="-1.0",Angle=str(a1))
             if (subbgd==1):
                 # Calculate a background correction
-                GroupDetectors(i+"det",OutputWorkspace=i+"bgd2",WorkspaceIndexList=range(*btmbgd),KeepUngroupedSpectra="0")
-                GroupDetectors(i+"det",OutputWorkspace=i+"bgd1",WorkspaceIndexList=range(*topbgd),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"det",OutputWorkspace=i+"bgd2",WorkspaceIndexList=list(range(*btmbgd)),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"det",OutputWorkspace=i+"bgd1",WorkspaceIndexList=list(range(*topbgd)),KeepUngroupedSpectra="0")
                 Plus(i+"bgd1",i+"bgd2",OutputWorkspace=i+"bgd")
                 wbgdtemp=mtd[i+"bgd"]/((btmbgd[1]-btmbgd[0])+(topbgd[1]-topbgd[0]))
                 DeleteWorkspace(i+"bgd1")
@@ -865,7 +866,7 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
                 Rebin(InputWorkspace=i+"det",OutputWorkspace=i+"det",Params=reb)
                 CropWorkspace(InputWorkspace=i+"det",OutputWorkspace=i+"detQ",StartWorkspaceIndex=int(minSpec)-current_detector.minspec,EndWorkspaceIndex=int(maxSpec)-current_detector.minspec)
                 ConvertUnits(InputWorkspace=i+"detQ",OutputWorkspace=i+"detQ",Target="MomentumTransfer",AlignBins="1")
-                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(maxSpec)-int(minSpec)+1),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(maxSpec)-int(minSpec)+1)),KeepUngroupedSpectra="0")
                 ConvertUnits(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Target="Wavelength",AlignBins="1")
                 Rebin(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Params=reb)
                 CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"mon",StartWorkspaceIndex=mon_spec,EndWorkspaceIndex=mon_spec)
@@ -878,7 +879,7 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
                 Rebin(InputWorkspace=i+"mon",OutputWorkspace=i+"mon",Params=reb)
                 Rebin(InputWorkspace=i+"det",OutputWorkspace=i+"det",Params=reb)
                 #GroupDetectors(InputWorkspace=i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-5,int(maxSpec)-5+1),KeepUngroupedSpectra="0")
-                GroupDetectors(InputWorkspace=i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-6,int(maxSpec)-6+1),KeepUngroupedSpectra="0")
+                GroupDetectors(InputWorkspace=i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-6,int(maxSpec)-6+1)),KeepUngroupedSpectra="0")
             Divide(LHSWorkspace=i+"sum",RHSWorkspace=i+"mon",OutputWorkspace=i+"norm")
             Divide(LHSWorkspace=i+"det",RHSWorkspace=i+"mon",OutputWorkspace=i+"detnorm")
             if dlist[k]  == "none":
@@ -964,9 +965,9 @@ def nrDBFn(runListShort,nameListShort,runListLong,nameListLong,nameListComb,minS
         else:
             #CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"det",StartWorkspaceIndex=current_detector.minspec-1,EndWorkspaceIndex=current_detector.maxspec-1) #old ld start=4 end=243, WorkSpaceIndex = Spectrum-1 
             current_detector.croptodetector(i)
-            print "short wavelengths: "+i+"det"
+            print("short wavelengths: "+i+"det")
             floodnorm(i+"det",floodfile,floodopt=dofloodnorm)
-            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
             Divide(i+"sum",i+"mon",OutputWorkspace=i+"norm")
             ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0", OutputWorkspace=i+"norm")
             
@@ -989,9 +990,9 @@ def nrDBFn(runListShort,nameListShort,runListLong,nameListLong,nameListComb,minS
         else: 
             #CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"det",StartWorkspaceIndex=current_detector.minspec-1,EndWorkspaceIndex=current_detector.maxspec-1) 
             current_detector.croptodetector(i)
-            print "long wavelengths: "+i+"det"
+            print("long wavelengths: "+i+"det")
             floodnorm(i+"det",floodfile,floodopt=dofloodnorm)
-            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0") #+1 for range function
+            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0") #+1 for range function
             Divide(i+"sum",i+"mon",OutputWorkspace=i+"norm")
             ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0",OutputWorkspace=i+"norm")
         
@@ -1109,13 +1110,13 @@ def NRCombineDatafn(RunsNameList,CombNameList,applySFs,SFList,SFError,scaleOptio
         if scaleOption != "2":
             Divide("i"+str(i)+"1temp","i"+str(i)+"2temp",OutputWorkspace="sf"+str(i))
             a1=mtd["sf"+str(i)]
-            print "sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0))
+            print("sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0)))
             sfs.append(str(a1.readY(0)[0]))
             sferrs.append(str(a1.readE(0)[0]))
         else:
             Divide("i"+str(i)+"2temp","i"+str(i)+"1temp",OutputWorkspace="sf"+str(i))
             a1=mtd["sf"+str(i)]
-            print "sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0))
+            print("sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0)))
             sfs.append(str(a1.readY(0)[0]))
             sferrs.append(str(a1.readE(0)[0]))
         DeleteWorkspace("i"+str(i)+"1temp")
@@ -1429,8 +1430,8 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
             if (nper>2):
                 for j in range(2,nper):
                     Plus("wbgdsum","bgdtemp"+"_"+pnums[j],OutputWorkspace="wbgdsum")
-            GroupDetectors("wbgdsum",OutputWorkspace="bgd2",WorkspaceIndexList=range(*current_detector.btm_background),KeepUngroupedSpectra="0")
-            GroupDetectors("wbgdsum",OutputWorkspace="bgd1",WorkspaceIndexList=range(*current_detector.top_background),KeepUngroupedSpectra="0")
+            GroupDetectors("wbgdsum",OutputWorkspace="bgd2",WorkspaceIndexList=list(range(*current_detector.btm_background)),KeepUngroupedSpectra="0")
+            GroupDetectors("wbgdsum",OutputWorkspace="bgd1",WorkspaceIndexList=list(range(*current_detector.top_background)),KeepUngroupedSpectra="0")
             Plus("bgd1","bgd2",OutputWorkspace="bgd")
             wbgdtemp=mtd["bgd"]/(self.nbackgroundspectra*nper)
             DeleteWorkspace("bgdtemp")
@@ -1469,9 +1470,9 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
                 # Subract a per spectrum background
                 Minus(wksp+"det",wbgdtemp,OutputWorkspace=wksp+"det")
                 ResetNegatives(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"det",AddMinimum='0',ResetValue="0.0")
-                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
             else:
-                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
             RebinToWorkspace(WorkspaceToRebin=wksp+"sum",WorkspaceToMatch=wksp+"mon",OutputWorkspace=wksp+"sum")
             Divide(LHSWorkspace=wksp+"sum",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"norm")
             RebinToWorkspace(WorkspaceToRebin=wksp+"det",WorkspaceToMatch=wksp+"mon",OutputWorkspace=wksp+"det")

--- a/reflectometry/offspec/offspec_offset2.py
+++ b/reflectometry/offspec/offspec_offset2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from math import *
 from mantid.simpleapi import *
 from mantid.api import WorkspaceGroup
@@ -28,7 +29,7 @@ class LinearDetector():
         self.specular = specular
         self.detectortype = "Linear"
         try:
-            self.nbackgroundspectra = len(range(*self.btm_background))+len(range(*self.top_background))
+            self.nbackgroundspectra = len(list(range(*self.btm_background)))+len(list(range(*self.top_background)))
         except: pass
     def croptodetector(self, inputworkspace, suffix = 'det'):
         CropWorkspace(InputWorkspace=inputworkspace,OutputWorkspace=inputworkspace+suffix,StartWorkspaceIndex=self.minspec-1,EndWorkspaceIndex=self.maxspec-1)
@@ -42,8 +43,8 @@ babylarmor = LinearDetector(specular = 120, minspec = 4, maxspec = 125, floodfil
 
 current_detector = wsf_detector
 
-print "Current default detector is: "+current_detector.name
-print "Change by setting the current_detector in this module (ask your local contact)."
+print("Current default detector is: "+current_detector.name)
+print("Change by setting the current_detector in this module (ask your local contact).")
 
 rad2deg=180.0/pi
 
@@ -69,14 +70,14 @@ def addRuns(runlist,wname):
         Load(str(runlist[0]),OutputWorkspace=output,LoadMonitors="Include")
     except:
         Load(str(runlist[0]),OutputWorkspace=output,LoadMonitors=1)
-        print "after load"
+        print("after load")
         if isinstance(mtd[output], WorkspaceGroup):
             numperiods = mtd[output].getNumberOfEntries()
 
             for period in range(1,numperiods+1):
                 suffix = "_"+str(period)
                 if isinstance(mtd[output+suffix],IEventWorkspace):
-                    print "in event"
+                    print("in event")
                     Rebin(output+suffix,'5.0,20.0,100000.0',PreserveEvents=False,OutputWorkspace=output+'reb'+suffix)
                     Rebin(output+'_monitors'+suffix,'5.0,20.0,100000.0',OutputWorkspace=output+"monreb"+suffix)
                     ConjoinWorkspaces(output+'monreb'+suffix,output+'reb'+suffix,CheckOverlapping=True)
@@ -84,7 +85,7 @@ def addRuns(runlist,wname):
                     #DeleteWorkspace(output+'_monitors')
             
         elif isinstance(mtd[output],IEventWorkspace):
-            print "in event"
+            print("in event")
             Rebin(output,'5.0,20.0,100000.0',PreserveEvents=False,OutputWorkspace=output+'reb')
             Rebin(output+'_monitors','5.0,20.0,100000.0',OutputWorkspace=output+'monreb')
             ConjoinWorkspaces(output+'monreb',output+'reb',CheckOverlapping=True)
@@ -130,14 +131,14 @@ def addRuns(runlist,wname):
         
         except:
             Load(str(runlist[0]),OutputWorkspace="wtemp",LoadMonitors=1)
-            print "after load"
+            print("after load")
             if isinstance(mtd["wtemp"], WorkspaceGroup):
                 numperiods = mtd["wtemp"].getNumberOfEntries()
 
                 for period in range(1,numperiods+1):
                     suffix = "_"+str(period)
                     if isinstance(mtd["wtemp"+suffix],IEventWorkspace):
-                        print "in event"
+                        print("in event")
                         Rebin("wtemp"+suffix,'5.0,20.0,100000.0',PreserveEvents=False,OutputWorkspace="wtemp"+'reb'+suffix)
                         Rebin("wtemp"+'_monitors'+suffix,'5.0,20.0,100000.0',OutputWorkspace="wtemp"+"monreb"+suffix)
                         ConjoinWorkspaces("wtemp"+'monreb'+suffix,"wtemp"+'reb'+suffix,CheckOverlapping=True)
@@ -145,7 +146,7 @@ def addRuns(runlist,wname):
                         #DeleteWorkspace(output+'_monitors')
             
             elif isinstance(mtd["wtemp"],IEventWorkspace):
-                print "in event"
+                print("in event")
                 Rebin("wtemp",'5.0,20.0,100000.0',PreserveEvents=False,OutputWorkspace="wtemp"+'reb')
                 Rebin("wtemp"+'_monitors','5.0,20.0,100000.0',OutputWorkspace="wtemp"+'monreb')
                 ConjoinWorkspaces("wtemp"+'monreb',"wtemp"+'reb',CheckOverlapping=True)
@@ -206,13 +207,13 @@ def parseRunList(istring):
                         tstr[j].strip()
                         tstr2=tstr[j].split('-')
                         tstr3=tstr2[1].split(':')
-                        r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+                        r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
                         for k in r1:
                             rlist2.append(str(k))
                     elif tstr[j].find('-') >=0:
                         tstr[j].strip()
                         tstr2=tstr[j].split('-')
-                        r1=range(int(tstr2[0]),int(tstr2[1])+1)
+                        r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
                         for k in r1:
                             rlist2.append(str(k))
                     else:
@@ -222,13 +223,13 @@ def parseRunList(istring):
                     rlist1[i].strip()
                     tstr2=rlist1[i].split('-')
                     tstr3=tstr2[1].split(':')
-                    r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+                    r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
                     for k in r1:
                         rlist2.append(str(k))
                 elif rlist1[i].find('-')>=0:
                     rlist1[i].strip()
                     tstr2=rlist1[i].split('-')
-                    r1=range(int(tstr2[0]),int(tstr2[1])+1)
+                    r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
                     for k in r1:
                         rlist2.append(str(k))
                 else:
@@ -262,13 +263,13 @@ def floodnorm(wkspName,floodfile='',floodopt='default'):
    else:
       flood_file = floodfile
    
-   print "using flood normalisation file "+flood_file
+   print("using flood normalisation file "+flood_file)
     
    flood_wksp = current_detector.nickname + "_flood"
    if  flood_wksp not in mtd:
        LoadNexusProcessed(Filename=flood_file,OutputWorkspace=flood_wksp)
        if current_detector.idf:
-        print "change idf"
+        print("change idf")
         LoadInstrument(flood_wksp, Filename = current_detector.idf,RewriteSpectraMap=False)
        ConvertUnits(flood_wksp, Target='Wavelength', OutputWorkspace =  flood_wksp)
         
@@ -400,7 +401,7 @@ def nrtestfn(runlist,wnames):
 def removeoutlayer(wksp):
     ''' remove counts from bins where there are so few counts it makes a mess of the polarisation
     calculation'''
-    print "removeoutlayer called"
+    print("removeoutlayer called")
     a1=mtd[wksp]
     nspec=a1.getNumberHistograms()
     x=a1.readX(0)
@@ -630,9 +631,9 @@ def nrCalcSEConst(RFFrequency,poleShoeAngle):
         B=34.288
     else:
         #B=2.0*34.288
-        print "\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
-        print "STOP IT!!!  You will NOT run the RF system above 1 MHz!"
-        print "\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+        print("\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+        print("STOP IT!!!  You will NOT run the RF system above 1 MHz!")
+        print("\n\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
         raise Exception("Spin Echo breaking attempt")
     h=6.62607e-34
     m=1.67493e-27
@@ -645,7 +646,7 @@ def nrCalcSEConst(RFFrequency,poleShoeAngle):
     th0=float(poleShoeAngle)
     th0=-0.0000000467796*(th0**5)+0.0000195413*(th0**4)-0.00326229*(th0**3)+0.271767*(th0**2)-10.4269*th0+198.108
     c1=Gl*m*2.0*B*L/(2.0*pi*h*tan(th0*pi/180.0)*1.0e20)
-    print "10A: "+str(c1*1e8)+", 4A: "+str(c1*1e8*4**2/100)
+    print("10A: "+str(c1*1e8)+", 4A: "+str(c1*1e8*4**2/100))
     return c1*1e8
     
 def plotSEconst(RFFrequency):
@@ -653,7 +654,7 @@ def plotSEconst(RFFrequency):
     poleshoestopangle = 90.0
     rffrequency = str(RFFrequency)
     angles = np.linspace(poleshoestartangle,poleshoestopangle, 100)
-    print angles
+    print(angles)
     SEC10 = [nrCalcSEConst(rffrequency, x) for x in angles]
     SEC4 = [y*4**2/10**2 for y in SEC10]
     
@@ -752,7 +753,7 @@ def nrSERGISFn(runList,nameList,P0runList,P0nameList,incidentAngles,SEConstants,
                 #a1=2.0*float(incAngles[k])+atan((float(minSpec)-float(specChan))*current_detector.pixelsize/3.63)*180.0/pi
                 #print str(2.0*float(incAngles[k]))+" "+str(atan((float(minSpec)-float(specChan))*1.2e-3/3.63)*180.0/pi)+" "+str(a1)
                 RotateInstrumentComponent(wksp+"det","DetectorBench",X="-1.0",Angle=str(a1))
-                GroupDetectors(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+                GroupDetectors(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
                 Divide(LHSWorkspace=wksp+"sum",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"norm")
                 Divide(LHSWorkspace=wksp+"det",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"detnorm")
                 floodnorm(wksp+"detnorm",floodopt=dofloodnorm)
@@ -824,20 +825,20 @@ def nrSERGISFn(runList,nameList,P0runList,P0nameList,incidentAngles,SEConstants,
 #
 def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gparams,floodfile='',subbgd=0,btmbgd=current_detector.btm_background,topbgd=current_detector.top_background,qgroup=0,dofloodnorm=True,usewkspname=0,sf=1.0,diagnostics=0):
     nlist=parseNameList(nameList)
-    print nlist
-    print usewkspname
-    print current_detector.nspec
+    print(nlist)
+    print(usewkspname)
+    print(current_detector.nspec)
     #logger.notice("This is the sample nameslist:"+str(nlist))
     if(usewkspname==0):
         rlist=parseRunList(runList)
     else:
         rlist=parseNameList(runList)
-        print rlist
+        print(rlist)
     logger.notice("This is the sample runlist:"+str(rlist))
     dlist=parseNameList(DBList)
     #logger.notice("This is the Direct Beam nameslist:"+str(dlist))
     incAngles=parseNameList(incidentAngles)
-    print incAngles
+    print(incAngles)
     #logger.notice("This incident Angles are:"+str(incAngles))
 
     if(usewkspname==0):
@@ -861,7 +862,7 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
                    DeleteWorkspace(j)
             RenameWorkspace(InputWorkspace="wtemp",OutputWorkspace=i)
         ConvertUnits(InputWorkspace=i,OutputWorkspace=i,Target="Wavelength",AlignBins="1")
-        print i
+        print(i)
         a1=mtd[i]
         nspec=a1.getNumberHistograms()
         if nspec == 4:
@@ -894,8 +895,8 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
             RotateInstrumentComponent(i+"det","DetectorBench",X="-1.0",Angle=str(twotheta))
             if (subbgd==1):
                 # Calculate a background correction
-                GroupDetectors(i+"det",OutputWorkspace=i+"bgd2",WorkspaceIndexList=range(*btmbgd),KeepUngroupedSpectra="0")
-                GroupDetectors(i+"det",OutputWorkspace=i+"bgd1",WorkspaceIndexList=range(*topbgd),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"det",OutputWorkspace=i+"bgd2",WorkspaceIndexList=list(range(*btmbgd)),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"det",OutputWorkspace=i+"bgd1",WorkspaceIndexList=list(range(*topbgd)),KeepUngroupedSpectra="0")
                 Plus(i+"bgd1",i+"bgd2",OutputWorkspace=i+"bgd")
                 wbgdtemp=mtd[i+"bgd"]/((btmbgd[1]-btmbgd[0])+(topbgd[1]-topbgd[0]))
                 DeleteWorkspace(i+"bgd1")
@@ -910,7 +911,7 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
                 Rebin(InputWorkspace=i+"det",OutputWorkspace=i+"det",Params=reb)
                 CropWorkspace(InputWorkspace=i+"det",OutputWorkspace=i+"detQ",StartWorkspaceIndex=int(minSpec)-current_detector.minspec,EndWorkspaceIndex=int(maxSpec)-current_detector.minspec)
                 ConvertUnits(InputWorkspace=i+"detQ",OutputWorkspace=i+"detQ",Target="MomentumTransfer",AlignBins="1")
-                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(maxSpec)-int(minSpec)+1),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(maxSpec)-int(minSpec)+1)),KeepUngroupedSpectra="0")
                 ConvertUnits(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Target="Wavelength",AlignBins="1")
                 Rebin(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Params=reb)
                 CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"mon",StartWorkspaceIndex=mon_spec,EndWorkspaceIndex=mon_spec)
@@ -923,7 +924,7 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
                 Rebin(InputWorkspace=i+"mon",OutputWorkspace=i+"mon",Params=reb)
                 Rebin(InputWorkspace=i+"det",OutputWorkspace=i+"det",Params=reb)
                 #GroupDetectors(InputWorkspace=i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-5,int(maxSpec)-5+1),KeepUngroupedSpectra="0")
-                GroupDetectors(InputWorkspace=i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-6,int(maxSpec)-6+1),KeepUngroupedSpectra="0")
+                GroupDetectors(InputWorkspace=i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-6,int(maxSpec)-6+1)),KeepUngroupedSpectra="0")
             Divide(LHSWorkspace=i+"sum",RHSWorkspace=i+"mon",OutputWorkspace=i+"norm")
             Divide(LHSWorkspace=i+"det",RHSWorkspace=i+"mon",OutputWorkspace=i+"detnorm")
             if dlist[k]  == "none":
@@ -1008,9 +1009,9 @@ def nrDBFn(runListShort,nameListShort,runListLong,nameListLong,nameListComb,minS
         else:
             #CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"det",StartWorkspaceIndex=current_detector.minspec-1,EndWorkspaceIndex=current_detector.maxspec-1) #old ld start=4 end=243, WorkSpaceIndex = Spectrum-1 
             current_detector.croptodetector(i)
-            print "short wavelengths: "+i+"det"
+            print("short wavelengths: "+i+"det")
             floodnorm(i+"det",floodfile,floodopt=dofloodnorm)
-            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
             Divide(i+"sum",i+"mon",OutputWorkspace=i+"norm")
             ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0", OutputWorkspace=i+"norm")
             
@@ -1033,9 +1034,9 @@ def nrDBFn(runListShort,nameListShort,runListLong,nameListLong,nameListComb,minS
         else: 
             #CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"det",StartWorkspaceIndex=current_detector.minspec-1,EndWorkspaceIndex=current_detector.maxspec-1) 
             current_detector.croptodetector(i)
-            print "long wavelengths: "+i+"det"
+            print("long wavelengths: "+i+"det")
             floodnorm(i+"det",floodfile,floodopt=dofloodnorm)
-            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0") #+1 for range function
+            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0") #+1 for range function
             Divide(i+"sum",i+"mon",OutputWorkspace=i+"norm")
             ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0",OutputWorkspace=i+"norm")
         
@@ -1153,13 +1154,13 @@ def NRCombineDatafn(RunsNameList,CombNameList,applySFs,SFList,SFError,scaleOptio
         if scaleOption != "2":
             Divide("i"+str(i)+"1temp","i"+str(i)+"2temp",OutputWorkspace="sf"+str(i))
             a1=mtd["sf"+str(i)]
-            print "sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0))
+            print("sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0)))
             sfs.append(str(a1.readY(0)[0]))
             sferrs.append(str(a1.readE(0)[0]))
         else:
             Divide("i"+str(i)+"2temp","i"+str(i)+"1temp",OutputWorkspace="sf"+str(i))
             a1=mtd["sf"+str(i)]
-            print "sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0))
+            print("sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0)))
             sfs.append(str(a1.readY(0)[0]))
             sferrs.append(str(a1.readE(0)[0]))
         DeleteWorkspace("i"+str(i)+"1temp")
@@ -1269,7 +1270,7 @@ def nrPNRCorrection(UpWksp,DownWksp,calibration=0):
     elif (calibration == 5):
     # Constants Based on Runs 36680-36691 and 36692-36695 analyser -0.1deg
     # RF Flippers on polariser and analyser side 0.5MHz November 2015
-        print "Applying pnr corrections 5, Nov 2015 0.5MHz"
+        print("Applying pnr corrections 5, Nov 2015 0.5MHz")
         crho=[0.944514,0.026548,-0.003837,0.000168]
         calpha=[0.944022,0.025639,-0.0035,0.000145]
         cAp=[0.980605,-0.002201,-0.00097,0.000014]
@@ -1357,7 +1358,7 @@ def nrPACorrection(UpUpWksp,UpDownWksp,DownUpWksp,DownDownWksp,calibration=0):
     elif (calibration == 4):
     # Constants Based on Runs 36680-36691 and 36692-36695 analyser -0.1deg
     # RF Flippers on polariser and analyser side 0.5MHz November 2015
-        print "Applying corrections 4, Nov 2015"
+        print("Applying corrections 4, Nov 2015")
         crho=[0.944514,0.026548,-0.003837,0.000168]
         calpha=[0.944022,0.025639,-0.0035,0.000145]
         cAp=[0.980605,-0.002201,-0.00097,0.000014]
@@ -1485,8 +1486,8 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
             if (nper>2):
                 for j in range(2,nper):
                     Plus("wbgdsum","bgdtemp"+"_"+pnums[j],OutputWorkspace="wbgdsum")
-            GroupDetectors("wbgdsum",OutputWorkspace="bgd2",WorkspaceIndexList=range(*current_detector.btm_background),KeepUngroupedSpectra="0")
-            GroupDetectors("wbgdsum",OutputWorkspace="bgd1",WorkspaceIndexList=range(*current_detector.top_background),KeepUngroupedSpectra="0")
+            GroupDetectors("wbgdsum",OutputWorkspace="bgd2",WorkspaceIndexList=list(range(*current_detector.btm_background)),KeepUngroupedSpectra="0")
+            GroupDetectors("wbgdsum",OutputWorkspace="bgd1",WorkspaceIndexList=list(range(*current_detector.top_background)),KeepUngroupedSpectra="0")
             Plus("bgd1","bgd2",OutputWorkspace="bgd")
             wbgdtemp=mtd["bgd"]/(current_detector.nbackgroundspectra*nper)
             DeleteWorkspace("bgdtemp")
@@ -1495,7 +1496,7 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
             DeleteWorkspace("bgd2")
             DeleteWorkspace("bgd")
           except:
-            print "Background subtraction failed for some reason. Perhaps you are running the point detector?"
+            print("Background subtraction failed for some reason. Perhaps you are running the point detector?")
             
         wksp=i
         ConvertUnits(InputWorkspace=wksp,OutputWorkspace=wksp,Target="Wavelength",AlignBins="1")
@@ -1518,7 +1519,7 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
             #MoveInstrumentComponent(wksp+"det","DetectorBench",Y=str((current_detector.centrespectrum-float(minSpec))*current_detector.pixelsize))
             # factor of 2 because we need 2theta and are given theta, second term in the sum corrects the angle if the reflection was misaligned
             a1=2.0*(float(incAngles[k]))+(atan((float(specChan)-current_detector.specular)*current_detector.pixelsize/current_detector.detectorposition)*rad2deg)
-            print "detectorangle: "+ str(a1/2.0)
+            print("detectorangle: "+ str(a1/2.0))
             #print str(2.0*float(incAngles[k]))+" "+str(atan((float(minSpec)-float(specChan))*1.2e-3/3.63)*180.0/pi)+" "+str(a1)
             RotateInstrumentComponent(wksp+"det","DetectorBench",X="-1.0",Angle=str(a1))
             floodnorm(wksp+"det",floodfile,floodopt=dofloodnorm)
@@ -1526,13 +1527,13 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
                 # Subract a per spectrum background
                 Minus(wksp+"det",wbgdtemp,OutputWorkspace=wksp+"det")
                 ResetNegatives(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"det",AddMinimum='0',ResetValue="0.0")
-                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
             # Experimental convert to Q before summing 
             if (qgroup==1):
                 Rebin(InputWorkspace=i+"det",OutputWorkspace=i+"det",Params=reb)
                 CropWorkspace(InputWorkspace=i+"det",OutputWorkspace=i+"detQ",StartWorkspaceIndex=int(minSpec)-current_detector.minspec,EndWorkspaceIndex=int(maxSpec)-current_detector.minspec)
                 ConvertUnits(InputWorkspace=i+"detQ",OutputWorkspace=i+"detQ",Target="MomentumTransfer",AlignBins="1")
-                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(maxSpec)-int(minSpec)+1),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(maxSpec)-int(minSpec)+1)),KeepUngroupedSpectra="0")
                 ConvertUnits(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Target="Wavelength",AlignBins="1")
                 Rebin(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Params=reb)
                 CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"mon",StartWorkspaceIndex=mon_spec,EndWorkspaceIndex=mon_spec)
@@ -1541,7 +1542,7 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
                 if not diagnostics:
                     DeleteWorkspace(i+"detQ")
             else:
-                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
             RebinToWorkspace(WorkspaceToRebin=wksp+"sum",WorkspaceToMatch=wksp+"mon",OutputWorkspace=wksp+"sum")
             Divide(LHSWorkspace=wksp+"sum",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"norm")
             RebinToWorkspace(WorkspaceToRebin=wksp+"det",WorkspaceToMatch=wksp+"mon",OutputWorkspace=wksp+"det")

--- a/reflectometry/offspec/offspec_olddetector.py
+++ b/reflectometry/offspec/offspec_olddetector.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from math import *
 from mantid.simpleapi import *
 from mantid.api import WorkspaceGroup
@@ -136,13 +137,13 @@ def parseRunList(istring):
 						tstr[j].strip()
 						tstr2=tstr[j].split('-')
 						tstr3=tstr2[1].split(':')
-						r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+						r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
 						for k in r1:
 							rlist2.append(str(k))
 					elif tstr[j].find('-') >=0:
 						tstr[j].strip()
 						tstr2=tstr[j].split('-')
-						r1=range(int(tstr2[0]),int(tstr2[1])+1)
+						r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
 						for k in r1:
 							rlist2.append(str(k))
 					else:
@@ -152,13 +153,13 @@ def parseRunList(istring):
 					rlist1[i].strip()
 					tstr2=rlist1[i].split('-')
 					tstr3=tstr2[1].split(':')
-					r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+					r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
 					for k in r1:
 						rlist2.append(str(k))
 				elif rlist1[i].find('-')>=0:
 					rlist1[i].strip()
 					tstr2=rlist1[i].split('-')
-					r1=range(int(tstr2[0]),int(tstr2[1])+1)
+					r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
 					for k in r1:
 						rlist2.append(str(k))
 				else:
@@ -188,15 +189,15 @@ def floodnorm(wkspName,floodfile):
    else:
       flood_file=floodfile
 
-   print "using flood normalisation file "+flood_file
+   print("using flood normalisation file "+flood_file)
 	
    flood_wksp = "ld240flood"
    if  flood_wksp not in mtd:
 	   LoadNexusProcessed(Filename=flood_file,OutputWorkspace=flood_wksp)
 	   ConvertUnits(flood_wksp,'Wavelength',OutputWorkspace=flood_wksp)
 
-   print flood_wksp
-   print wkspName
+   print(flood_wksp)
+   print(wkspName)
    #CloneWorkspace(flood_wksp,OutputWorkspace='floodreb') #Rebin to Workspace crashed when clone workspace before, maybe it needed a fresh outputname??? njs
    floodtemp=mtd[flood_wksp]*1.0
    RebinToWorkspace(floodtemp,wkspName,OutputWorkspace='floodreb')
@@ -565,7 +566,7 @@ def nrCalcSEConst(RFFrequency,poleShoeAngle):
 	th0=float(poleShoeAngle)
 	th0=-0.0000000467796*(th0**5)+0.0000195413*(th0**4)-0.00326229*(th0**3)+0.271767*(th0**2)-10.4269*th0+198.108
 	c1=Gl*m*2.0*B*L/(2.0*pi*h*tan(th0*pi/180.0)*1.0e20)
-	print c1*1e8
+	print(c1*1e8)
 	return c1*1e8
 #
 #===========================================================
@@ -660,7 +661,7 @@ def nrSERGISFn(runList,nameList,P0runList,P0nameList,incidentAngles,SEConstants,
 				a1=2.0*float(incAngles[k])+atan((float(minSpec)-float(specChan))*1.2e-3/3.53)*180.0/pi
 				#print str(2.0*float(incAngles[k]))+" "+str(atan((float(minSpec)-float(specChan))*1.2e-3/3.63)*180.0/pi)+" "+str(a1)
 				RotateInstrumentComponent(wksp+"det","DetectorBench",X="-1.0",Angle=str(a1))
-				GroupDetectors(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-5,int(maxSpec)-5+1),KeepUngroupedSpectra="0")
+				GroupDetectors(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-5,int(maxSpec)-5+1)),KeepUngroupedSpectra="0")
 				Divide(LHSWorkspace=wksp+"sum",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"norm")
 				Divide(LHSWorkspace=wksp+"det",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"detnorm")
 				floodnorm(wksp+"detnorm",floodfile)
@@ -792,8 +793,8 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
 			RotateInstrumentComponent(i+"det","DetectorBench",X="-1.0",Angle=str(a1))
 			if (subbgd==1):
 				# Calculate a background correction
-				GroupDetectors(i+"det",OutputWorkspace=i+"bgd2",WorkspaceIndexList=range(btmbgd[0],btmbgd[1]),KeepUngroupedSpectra="0")
-				GroupDetectors(i+"det",OutputWorkspace=i+"bgd1",WorkspaceIndexList=range(topbgd[0],topbgd[1]),KeepUngroupedSpectra="0")
+				GroupDetectors(i+"det",OutputWorkspace=i+"bgd2",WorkspaceIndexList=list(range(btmbgd[0],btmbgd[1])),KeepUngroupedSpectra="0")
+				GroupDetectors(i+"det",OutputWorkspace=i+"bgd1",WorkspaceIndexList=list(range(topbgd[0],topbgd[1])),KeepUngroupedSpectra="0")
 				Plus(i+"bgd1",i+"bgd2",OutputWorkspace=i+"bgd")
 				wbgdtemp=mtd[i+"bgd"]/((btmbgd[1]-btmbgd[0])+(topbgd[1]-topbgd[0]))
 				DeleteWorkspace(i+"bgd1")
@@ -808,7 +809,7 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
 				Rebin(InputWorkspace=i+"det",OutputWorkspace=i+"det",Params=reb)
 				CropWorkspace(InputWorkspace=i+"det",OutputWorkspace=i+"detQ",StartWorkspaceIndex=int(minSpec)-5,EndWorkspaceIndex=int(maxSpec)-5+1)
 				ConvertUnits(InputWorkspace=i+"detQ",OutputWorkspace=i+"detQ",Target="MomentumTransfer",AlignBins="1")
-				GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=range(0,int(maxSpec)-int(minSpec)),KeepUngroupedSpectra="0")
+				GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(0,int(maxSpec)-int(minSpec))),KeepUngroupedSpectra="0")
 				ConvertUnits(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Target="Wavelength",AlignBins="1")
 				Rebin(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Params=reb)
 				CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"mon",StartWorkspaceIndex=mon_spec,EndWorkspaceIndex=mon_spec)
@@ -819,7 +820,7 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
 				CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"mon",StartWorkspaceIndex=mon_spec,EndWorkspaceIndex=mon_spec)
 				Rebin(InputWorkspace=i+"mon",OutputWorkspace=i+"mon",Params=reb)
 				Rebin(InputWorkspace=i+"det",OutputWorkspace=i+"det",Params=reb)
-				GroupDetectors(InputWorkspace=i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-5,int(maxSpec)-5+1),KeepUngroupedSpectra="0")
+				GroupDetectors(InputWorkspace=i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-5,int(maxSpec)-5+1)),KeepUngroupedSpectra="0")
 			Divide(LHSWorkspace=i+"sum",RHSWorkspace=i+"mon",OutputWorkspace=i+"norm")
 			Divide(LHSWorkspace=i+"det",RHSWorkspace=i+"mon",OutputWorkspace=i+"detnorm")
 			if dlist[k]  == "none":
@@ -903,9 +904,9 @@ def nrDBFn(runListShort,nameListShort,runListLong,nameListLong,nameListComb,minS
 			ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0",OutputWorkspace=i+"norm")
 		else:
 			CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"det",StartWorkspaceIndex=4,EndWorkspaceIndex=243)
-			print i+"det"
+			print(i+"det")
 			floodnorm(i+"det",floodfile)
-			GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-5,int(maxSpec)-5+1),KeepUngroupedSpectra="0")
+			GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-5,int(maxSpec)-5+1)),KeepUngroupedSpectra="0")
 			Divide(i+"sum",i+"mon",OutputWorkspace=i+"norm")
 			ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0", OutputWorkspace=i+"norm")
 			
@@ -928,7 +929,7 @@ def nrDBFn(runListShort,nameListShort,runListLong,nameListLong,nameListComb,minS
 		else:
 			CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"det",StartWorkspaceIndex=4,EndWorkspaceIndex=243)
 			floodnorm(i+"det",floodfile)
-			GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-5,int(maxSpec)-5+1),KeepUngroupedSpectra="0")
+			GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-5,int(maxSpec)-5+1)),KeepUngroupedSpectra="0")
 			Divide(i+"sum",i+"mon",OutputWorkspace=i+"norm")
 			ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0",OutputWorkspace=i+"norm")
 		
@@ -1046,13 +1047,13 @@ def NRCombineDatafn(RunsNameList,CombNameList,applySFs,SFList,SFError,scaleOptio
 		if scaleOption != "2":
 			Divide("i"+str(i)+"1temp","i"+str(i)+"2temp",OutputWorkspace="sf"+str(i))
 			a1=mtd["sf"+str(i)]
-			print "sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0))
+			print("sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0)))
 			sfs.append(str(a1.readY(0)[0]))
 			sferrs.append(str(a1.readE(0)[0]))
 		else:
 			Divide("i"+str(i)+"2temp","i"+str(i)+"1temp",OutputWorkspace="sf"+str(i))
 			a1=mtd["sf"+str(i)]
-			print "sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0))
+			print("sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0)))
 			sfs.append(str(a1.readY(0)[0]))
 			sferrs.append(str(a1.readE(0)[0]))
 		DeleteWorkspace("i"+str(i)+"1temp")
@@ -1360,8 +1361,8 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
 			if (nper>2):
 				for j in range(2,nper):
 					Plus("wbgdsum","bgdtemp"+"_"+pnums[j],OutputWorkspace="wbgdsum")
-			GroupDetectors("wbgdsum",OutputWorkspace="bgd2",WorkspaceIndexList=range(0,50),KeepUngroupedSpectra="0")
-			GroupDetectors("wbgdsum",OutputWorkspace="bgd1",WorkspaceIndexList=range(160,240),KeepUngroupedSpectra="0")
+			GroupDetectors("wbgdsum",OutputWorkspace="bgd2",WorkspaceIndexList=list(range(0,50)),KeepUngroupedSpectra="0")
+			GroupDetectors("wbgdsum",OutputWorkspace="bgd1",WorkspaceIndexList=list(range(160,240)),KeepUngroupedSpectra="0")
 			Plus("bgd1","bgd2",OutputWorkspace="bgd")
 			wbgdtemp=mtd["bgd"]/(130.0*nper)
 			DeleteWorkspace("bgdtemp")
@@ -1398,9 +1399,9 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
 				# Subract a per spectrum background
 				Minus(wksp+"det",wbgdtemp,OutputWorkspace=wksp+"det")
 				ResetNegatives(InputWorkspace=wksp+"det",OutputWorkspace=wksp+"det",AddMinimum='0',ResetValue="0.0")
-				GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-5,int(maxSpec)-5+1),KeepUngroupedSpectra="0")
+				GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-5,int(maxSpec)-5+1)),KeepUngroupedSpectra="0")
 			else:
-				GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-5,int(maxSpec)-5+1),KeepUngroupedSpectra="0")
+				GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-5,int(maxSpec)-5+1)),KeepUngroupedSpectra="0")
 			RebinToWorkspace(WorkspaceToRebin=wksp+"sum",WorkspaceToMatch=wksp+"mon",OutputWorkspace=wksp+"sum")
 			Divide(LHSWorkspace=wksp+"sum",RHSWorkspace=wksp+"mon",OutputWorkspace=wksp+"norm")
 			RebinToWorkspace(WorkspaceToRebin=wksp+"det",WorkspaceToMatch=wksp+"mon",OutputWorkspace=wksp+"det")

--- a/reflectometry/offspec/offspec_red.py
+++ b/reflectometry/offspec/offspec_red.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from math import *
 #27/06 njs: add check on latest run files and change data loader frfom Load to LoadISISNexus
 from mantid.simpleapi import *
@@ -102,10 +103,10 @@ def check_is_host_at_isis():
     reobject = re.compile('isis', re.IGNORECASE)
     matchobject = reobject.search(hostname.lower()) 
     if matchobject: 
-        print "This is "+thisinstrument+" at ISIS"
+        print("This is "+thisinstrument+" at ISIS")
         return True
     else: 
-        print "You are on a local machine"
+        print("You are on a local machine")
         return False
     
 old_detector = LinearDetector(specular = 114, minspec = 5, maxspec = 244, floodfile = "LD240flood_premarch2012.nxs", detectorposition = 3.63, name = 'Old_LD', nickname = 'oldLD', btm_background = (10, 50), top_background = (160, 230), pixelsize = 1.2e-3)        
@@ -118,8 +119,8 @@ babylarmor = LinearDetector(specular = 120, minspec = 4, maxspec = 125, floodfil
 current_detector = wsf_detector
 thishost = "ndxoffspec"
 thisinstrument = "OFFSPEC"
-print "Current default detector is: "+current_detector.name
-print "Change by setting the current_detector in this module (ask your local contact)."
+print("Current default detector is: "+current_detector.name)
+print("Change by setting the current_detector in this module (ask your local contact).")
 
 rad2deg=180.0/pi
 pulsestart = 0.5 # be generous here, this is just a rough chop to avoid 0 errors in the unit conversion
@@ -131,7 +132,7 @@ if check_is_host_at_isis():
         currentRun = CurrentRun("//ndloffspec1/L/RawData/")
     except:
         currentRun = CurrentRun("//isis/inst$/NDXOFFSPEC/Instrument/data/")
-        print "ndloffspec is missing, using the archive."
+        print("ndloffspec is missing, using the archive.")
 else:
 	currentRun = NotAtHome()
 
@@ -161,7 +162,7 @@ class PolarisationCalibration():
         return thecalibration
         
     def correctPNR(self, UpWksp, DownWksp):  
-        print "Applying polarisation corrections "+str(self.name)
+        print("Applying polarisation corrections "+str(self.name))
         Ip = mtd[UpWksp]
         Ia = mtd[DownWksp]
         CloneWorkspace(Ip,OutputWorkspace="PCalpha")
@@ -197,7 +198,7 @@ class PolarisationCalibration():
         DeleteWorkspace("D")
     
     def correctPA(self, UpUpWksp, UpDownWksp, DownUpWksp, DownDownWksp):
-        print "Applying polarisation corrections "+str(self.name)
+        print("Applying polarisation corrections "+str(self.name))
         Ipp = mtd[UpUpWksp]
         Ipa = mtd[UpDownWksp]
         Iap = mtd[DownUpWksp]
@@ -324,7 +325,7 @@ def addRuns(runlist,wname):
         # Live data doesn't return an event mode data set.. only histograms
         load_livedata_once(run, outputworkspace="wtemp")
     elif runis == "DoesNotExistYet":
-        print "This is not a valid Run. I will ignore it."
+        print("This is not a valid Run. I will ignore it.")
         return "Run Does Not exist"
     # why are we doing this? need to find out    
     if isinstance(mtd["wtemp"], WorkspaceGroup):
@@ -356,13 +357,13 @@ def parseRunList(istring):
                         tstr[j].strip()
                         tstr2=tstr[j].split('-')
                         tstr3=tstr2[1].split(':')
-                        r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+                        r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
                         for k in r1:
                             rlist2.append(str(k))
                     elif tstr[j].find('-') >=0:
                         tstr[j].strip()
                         tstr2=tstr[j].split('-')
-                        r1=range(int(tstr2[0]),int(tstr2[1])+1)
+                        r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
                         for k in r1:
                             rlist2.append(str(k))
                     else:
@@ -372,13 +373,13 @@ def parseRunList(istring):
                     rlist1[i].strip()
                     tstr2=rlist1[i].split('-')
                     tstr3=tstr2[1].split(':')
-                    r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+                    r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
                     for k in r1:
                         rlist2.append(str(k))
                 elif rlist1[i].find('-')>=0:
                     rlist1[i].strip()
                     tstr2=rlist1[i].split('-')
-                    r1=range(int(tstr2[0]),int(tstr2[1])+1)
+                    r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
                     for k in r1:
                         rlist2.append(str(k))
                 else:
@@ -414,7 +415,7 @@ def floodnorm(wkspName,floodfile='',floodopt='default'):
    if  flood_wksp not in mtd:
        LoadNexusProcessed(Filename=flood_file,OutputWorkspace=flood_wksp)
        if current_detector.idf:
-        print "change idf"
+        print("change idf")
         LoadInstrument(flood_wksp, InstrumentName=thisinstrument, RewriteSpectraMap=False)
        ConvertUnits(flood_wksp, Target='Wavelength', OutputWorkspace =  flood_wksp)
 
@@ -480,27 +481,27 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
             RotateInstrumentComponent(i+"det","DetectorBench",X="-1.0",Angle=str(twotheta))
             #print str(2.0*float(incAngles[k])+atan((-float(specChan)+current_detector.specular)*current_detector.pixelsize/current_detector.detectorposition)*rad2deg)
             if qgroup:
-                print "Summing detectors in Q."
+                print("Summing detectors in Q.")
                 CropWorkspace(InputWorkspace=i+"det",OutputWorkspace=i+"detQ",XMin = pulsestart, XMax= pulseend, StartWorkspaceIndex=int(minSpec)-current_detector.minspec,EndWorkspaceIndex=int(maxSpec)-current_detector.minspec)
                 ConvertUnits(InputWorkspace=i+"detQ",OutputWorkspace=i+"detQ",Target="MomentumTransfer",AlignBins=True)
-                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(maxSpec)-int(minSpec)+1),KeepUngroupedSpectra=False)
+                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(maxSpec)-int(minSpec)+1)),KeepUngroupedSpectra=False)
                 ConvertUnits(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Target="Wavelength",AlignBins=True)
 
                 if not diagnostics:
                     DeleteWorkspace(i+"detQ")
             else:
-                print "Summing detectors in lambda."
-                GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra=False)
+                print("Summing detectors in lambda.")
+                GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra=False)
                 
             CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"mon",StartWorkspaceIndex=mon_spec,EndWorkspaceIndex=mon_spec)
             Rebin(InputWorkspace=i+"mon",OutputWorkspace=i+"mon",Params=reb)
             RebinToWorkspace(WorkspaceToRebin=i+"sum",WorkspaceToMatch=i+"mon",OutputWorkspace=i+"sum")
             RebinToWorkspace(WorkspaceToRebin=i+"det",WorkspaceToMatch=i+"mon",OutputWorkspace=i+"det")
             if subbgd:
-                print "Applying very light background correction. This is not necessarily all(or what) you want to do."
+                print("Applying very light background correction. This is not necessarily all(or what) you want to do.")
                 # Calculate a background correction
-                GroupDetectors(i+"det",OutputWorkspace=i+"bgd2",WorkspaceIndexList=range(*btmbgd),KeepUngroupedSpectra="0")
-                GroupDetectors(i+"det",OutputWorkspace=i+"bgd1",WorkspaceIndexList=range(*topbgd),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"det",OutputWorkspace=i+"bgd2",WorkspaceIndexList=list(range(*btmbgd)),KeepUngroupedSpectra="0")
+                GroupDetectors(i+"det",OutputWorkspace=i+"bgd1",WorkspaceIndexList=list(range(*topbgd)),KeepUngroupedSpectra="0")
                 Plus(i+"bgd1",i+"bgd2",OutputWorkspace=i+"bgd")
                 wbgdtemp=mtd[i+"bgd"]/((btmbgd[1]-btmbgd[0])+(topbgd[1]-topbgd[0]))
                 DeleteWorkspace(i+"bgd1")
@@ -545,7 +546,7 @@ def nrNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpara
             DeleteWorkspace(i+"mon")
             DeleteWorkspace(i+"det")
       except KeyError:
-        print str(i)+"Does Not exist"  
+        print(str(i)+"Does Not exist")  
 
 def numberofbins(wksp):
     a1=mtd[wksp]
@@ -620,9 +621,9 @@ def nrDBFn(runListShort,nameListShort,runListLong,nameListLong,nameListComb,minS
         else:
             #CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"det",StartWorkspaceIndex=current_detector.minspec-1,EndWorkspaceIndex=current_detector.maxspec-1) #old ld start=4 end=243, WorkSpaceIndex = Spectrum-1 
             current_detector.croptodetector(i)
-            print "short wavelengths: "+i+"det"
+            print("short wavelengths: "+i+"det")
             floodnorm(i+"det",floodfile,floodopt=dofloodnorm)
-            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0")
+            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0")
             Divide(i+"sum",i+"mon",OutputWorkspace=i+"norm")
             ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0", OutputWorkspace=i+"norm")
             
@@ -645,9 +646,9 @@ def nrDBFn(runListShort,nameListShort,runListLong,nameListLong,nameListComb,minS
         else: 
             #CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"det",StartWorkspaceIndex=current_detector.minspec-1,EndWorkspaceIndex=current_detector.maxspec-1) 
             current_detector.croptodetector(i)
-            print "long wavelengths: "+i+"det"
+            print("long wavelengths: "+i+"det")
             floodnorm(i+"det",floodfile,floodopt=dofloodnorm)
-            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra="0") #+1 for range function
+            GroupDetectors(i+"det",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra="0") #+1 for range function
             Divide(i+"sum",i+"mon",OutputWorkspace=i+"norm")
             ReplaceSpecialValues(i+"norm","0.0","0.0","0.0","0.0",OutputWorkspace=i+"norm")
         
@@ -736,13 +737,13 @@ def NRCombineDatafn(RunsNameList,CombNameList,applySFs,SFList,SFError,scaleOptio
         if scaleOption != "2":
             Divide("i"+str(i)+"1temp","i"+str(i)+"2temp",OutputWorkspace="sf"+str(i))
             a1=mtd["sf"+str(i)]
-            print "sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0))
+            print("sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0)))
             sfs.append(str(a1.readY(0)[0]))
             sferrs.append(str(a1.readE(0)[0]))
         else:
             Divide("i"+str(i)+"2temp","i"+str(i)+"1temp",OutputWorkspace="sf"+str(i))
             a1=mtd["sf"+str(i)]
-            print "sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0))
+            print("sf"+str(i)+"="+str(a1.readY(0))+" +/- "+str(a1.readE(0)))
             sfs.append(str(a1.readY(0)[0]))
             sferrs.append(str(a1.readE(0)[0]))
         DeleteWorkspace("i"+str(i)+"1temp")
@@ -843,17 +844,17 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
             
             # Experimental convert to Q before summing 
             if qgroup:
-                print "Summing detectors in Q."
+                print("Summing detectors in Q.")
                 CropWorkspace(InputWorkspace=i+"det",OutputWorkspace=i+"detQ",XMin=pulsestart, XMax=pulseend, StartWorkspaceIndex=int(minSpec)-current_detector.minspec,EndWorkspaceIndex=int(maxSpec)-current_detector.minspec)
                 ConvertUnits(InputWorkspace=i+"detQ",OutputWorkspace=i+"detQ",Target="MomentumTransfer", AlignBins = True)
-                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=range(int(maxSpec)-int(minSpec)+1),KeepUngroupedSpectra=False)
+                GroupDetectors(i+"detQ",OutputWorkspace=i+"sum",WorkspaceIndexList=list(range(int(maxSpec)-int(minSpec)+1)),KeepUngroupedSpectra=False)
                 ConvertUnits(InputWorkspace=i+"sum",OutputWorkspace=i+"sum",Target="Wavelength",AlignBins=True)
                 if not diagnostics:
                     DeleteWorkspace(i+"detQ")
             
             else:
-                print "Summing detectors in lambda"
-                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1),KeepUngroupedSpectra=False)
+                print("Summing detectors in lambda")
+                GroupDetectors(wksp+"det",OutputWorkspace=wksp+"sum",WorkspaceIndexList=list(range(int(minSpec)-current_detector.minspec,int(maxSpec)-current_detector.minspec+1)),KeepUngroupedSpectra=False)
             
             CropWorkspace(InputWorkspace=i,OutputWorkspace=i+"mon",StartWorkspaceIndex=mon_spec,EndWorkspaceIndex=mon_spec)
             Rebin(InputWorkspace=i+"mon",OutputWorkspace=i+"mon",Params=reb)
@@ -861,7 +862,7 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
             RebinToWorkspace(WorkspaceToRebin=wksp+"det",WorkspaceToMatch=wksp+"mon",OutputWorkspace=wksp+"det")
              
             if subbgd:
-                print "Applying very light background correction. This is not necessarily all (or what) you want to do."
+                print("Applying very light background correction. This is not necessarily all (or what) you want to do.")
                 CloneWorkspace(i, OutputWorkspace="bgdtemp")
                 ConvertUnits(InputWorkspace="bgdtemp",OutputWorkspace="bgdtemp",Target="Wavelength",AlignBins=True)
                 Rebin(InputWorkspace="bgdtemp",OutputWorkspace="bgdtemp",Params=reb)
@@ -869,8 +870,8 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
                 Plus("bgdtemp"+"_"+pnums[0],"bgdtemp"+"_"+pnums[1],OutputWorkspace="wbgdsum")
                 for j in range(2,nper):
                     Plus("wbgdsum","bgdtemp"+"_"+pnums[j],OutputWorkspace="wbgdsum")
-                GroupDetectors("wbgdsum",OutputWorkspace="bgd2",WorkspaceIndexList=range(*current_detector.btm_background),KeepUngroupedSpectra=False)
-                GroupDetectors("wbgdsum",OutputWorkspace="bgd1",WorkspaceIndexList=range(*current_detector.top_background),KeepUngroupedSpectra=False)
+                GroupDetectors("wbgdsum",OutputWorkspace="bgd2",WorkspaceIndexList=list(range(*current_detector.btm_background)),KeepUngroupedSpectra=False)
+                GroupDetectors("wbgdsum",OutputWorkspace="bgd1",WorkspaceIndexList=list(range(*current_detector.top_background)),KeepUngroupedSpectra=False)
                 Plus("bgd1","bgd2",OutputWorkspace="bgd")
                 wbgdtemp=mtd["bgd"]/(current_detector.nbackgroundspectra*nper)
                 DeleteWorkspace("bgdtemp")
@@ -938,5 +939,5 @@ def nrPNRFn(runList,nameList,incidentAngles,DBList,specChan,minSpec,maxSpec,gpar
         
 if __name__ == '__main__':
 
-    print socket.getfqdn()
-    print check_is_host_at_isis()
+    print(socket.getfqdn())
+    print(check_is_host_at_isis())

--- a/reflectometry/offspec/useful.py
+++ b/reflectometry/offspec/useful.py
@@ -13,10 +13,10 @@ def open_file(filename):
     try:
         thefile = open(filename, 'r')
     except IOError as error:
-        print(("Problem opening file {file}: {fileerror}".format(file=filename, fileerror=error)))
+        print("Problem opening file {file}: {fileerror}".format(file=filename, fileerror=error))
         if thefile != None:
             thefile.close()
-            print(("Could not open file " + filename + "\n"))
+            print("Could not open file " + filename + "\n")
     return thefile
 
 def save_dat(filename, data, coldelimiter = "\t"):

--- a/reflectometry/offspec/useful.py
+++ b/reflectometry/offspec/useful.py
@@ -1,21 +1,22 @@
+from __future__ import print_function
 import numpy as np
 import re, csv
 import matplotlib.pyplot as plt
 
 def pretty_print(name, parameter):
-  print "==================="
-  print "The value of "+name+" is:\n"
-  print parameter
-  print"\n===================\n"
+  print("===================")
+  print("The value of "+name+" is:\n")
+  print(parameter)
+  print("\n===================\n")
 
 def open_file(filename):
     try:
         thefile = open(filename, 'r')
     except IOError as error:
-        print("Problem opening file {file}: {fileerror}".format(file=filename, fileerror=error))
+        print(("Problem opening file {file}: {fileerror}".format(file=filename, fileerror=error)))
         if thefile != None:
             thefile.close()
-            print("Could not open file " + filename + "\n")
+            print(("Could not open file " + filename + "\n"))
     return thefile
 
 def save_dat(filename, data, coldelimiter = "\t"):
@@ -28,7 +29,7 @@ def save_dat(filename, data, coldelimiter = "\t"):
 
 def save_dict(filename, dictionary, coldelimiter = "\t"):
     outputfile = open(filename, 'wb')
-    for key in dictionary.keys():
+    for key in list(dictionary.keys()):
         line = str(key) + coldelimiter + str(dictionary[key]) + '\n'
         outputfile.write(line)
     del line
@@ -70,7 +71,7 @@ def generate_genx_filenames(inputfilename, howmany = 1):
 	fullname = inputfilename.split('.',1)
 	filenames = []
 	counter = int(fullname[0][-1])
-	print fullname[0][:-1]
+	print(fullname[0][:-1])
 	for each in range(howmany):
 		counter += 1
 		newname = fullname[0][:-1]+str(int(counter))+'.dat'
@@ -102,15 +103,15 @@ def find_spinfiles(filename, filename2 = None):
             spinstate['.d'] = read_dat_file(filename2)
         else:
             raise Exception('Not enough spin states supplied, could not find two valid files.')
-    if '.u' in spinstate.keys():
+    if '.u' in list(spinstate.keys()):
       spinup = spinstate['.u']
-    elif '.uu' in spinstate.keys():
+    elif '.uu' in list(spinstate.keys()):
       spinup = spinstate['.uu']
     else: raise Exception('Spinup not found!')
   
-    if '.d' in spinstate.keys():
+    if '.d' in list(spinstate.keys()):
       spindown = spinstate['.d']
-    elif '.dd' in spinstate.keys():
+    elif '.dd' in list(spinstate.keys()):
       spindown = spinstate['.dd']
     else: raise Exception('Spindown not found!')
     pretty_print("spinup shape", spinup.shape)
@@ -197,7 +198,7 @@ def genx2sa(filename, filename2 = None):
   
 def plotgenxsa(filename, xlim = (0.008, 0.2), ylim = (-1, 1)):
 	filename2 = generate_genx_filenames(filename)
-	print filename2
+	print(filename2)
 	sa = genx2sa(filename, filename2[0])
 	plt.figure(1,figsize=(25,15))
 	plt.ylim(*ylim)
@@ -211,8 +212,8 @@ def plotgenxsa(filename, xlim = (0.008, 0.2), ylim = (-1, 1)):
 def pairwise(iterable):
     "s -> (s0,s1), (s1,s2), (s2, s3), ..."
     a, b = tee(iterable)
-    list = izip(a,b)
-    print type(list)
+    list = zip(a,b)
+    print(type(list))
     next(b, None)
     return list
 	
@@ -231,10 +232,10 @@ def theta2Q(theta, lambdas=None):
 		test = lambdas[0] #is it iterable?
 	except:
 		lambdas = [lambdas] # make it iterable
-	print "For theta = "+str(theta)	
+	print("For theta = "+str(theta))	
 	for l in lambdas:
 		q = 4*np.pi*np.sin(theta/180*np.pi)/l
-		print "lambda: "+str(l)+' -> Q: {:.4f}'.format(q)
+		print("lambda: "+str(l)+' -> Q: {:.4f}'.format(q))
 			
 def Q2theta(Q, lambdas=None):
 	'''
@@ -251,10 +252,10 @@ def Q2theta(Q, lambdas=None):
 		test = lambdas[0] # is it iterable?
 	except:
 		lambdas = [lambdas] # now it is
-	print "For Q = "+str(Q)
+	print("For Q = "+str(Q))
 	for l in lambdas:
 		theta = np.arcsin(l*Q/(4*np.pi))/np.pi*180
-		print "lambda: "+str(l)+' -> theta: {:.3f}'.format(theta)
+		print("lambda: "+str(l)+' -> theta: {:.3f}'.format(theta))
 
 def remove_unwanted_sld_characters(textline):
     # these are very genx sld file specific, the number format is (0.000e+01+0.0000e-01)

--- a/reflectometry/updates/algorithms/Stitch1D.py
+++ b/reflectometry/updates/algorithms/Stitch1D.py
@@ -6,6 +6,7 @@ are not provided, then these are taken to be the region of x-axis intersection.
 
 The workspaces must be histogrammed. Use [[ConvertToHistogram]] on workspaces prior to passing them to this algorithm.
 *WIKI*"""
+from __future__ import print_function
 from mantid.simpleapi import *
 
 from mantid.api import *
@@ -61,7 +62,7 @@ class Stitch1D(PythonAlgorithm):
             alg.setPropertyValue("OutputWorkspace","UNUSED_NAME_FOR_CHILD")
         
         alg.setRethrows(True)
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             alg.setProperty(key, value)
         
         alg.execute()
@@ -134,7 +135,7 @@ class Stitch1D(PythonAlgorithm):
         outScaleFactor = self.getProperty('OutScaleFactor').value
         
         params = self.__create_rebin_parameters()
-        print params
+        print(params)
         lhs_rebinned = self.__run_as_child("Rebin", InputWorkspace=self.getProperty("LHSWorkspace").value, Params=params)
         rhs_rebinned = self.__run_as_child("Rebin", InputWorkspace=self.getProperty("RHSWorkspace").value, Params=params)
         

--- a/sans/BILBY/BilbyCustomFunctions_Reduction.py
+++ b/sans/BILBY/BilbyCustomFunctions_Reduction.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.api import *
 from mantid.simpleapi import *
 import csv, math, sys
@@ -63,7 +64,7 @@ def evaluate_files_list(numbers):
     for number in numbers.split(","):
         if "-" in number:
             start, end = number.split("-")
-            nrs = range(int(start), int(end) + 1)
+            nrs = list(range(int(start), int(end) + 1))
             expanded.extend(nrs)
         else:
             expanded.append(int(number))
@@ -125,7 +126,7 @@ def AttenuationCorrection(att_pos, data_before_May_2016):
     """ Bilby has four attenuators; before May 2016 there were only two. Value of the attenuators are hard coded here and being used for the I(Q) scaling in Q1D """
 
     if (data_before_May_2016):
-        print "You stated data have been collected before May, 2016, i.e. using old attenuators. Please double check."
+        print("You stated data have been collected before May, 2016, i.e. using old attenuators. Please double check.")
         if (att_pos == 2.0 or att_pos == 4.0):
             #print "Wrong attenuators value; Either data have been collected after May, 2016, or something is wrong with hdf file"
             #sys.exit()
@@ -181,7 +182,7 @@ def wavelengh_slices(wavelength_intervals, binning_wavelength_ini, wav_delta):
         else:                                                                          # if reminder is greater than 0, to trancate the maximum wavelength in the range
             n = math.floor((wav2 - wav1)/wav_delta)
             max_wave_length = wav1 + n*wav_delta           
-            print ('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length)
+            print(('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length))
 
         # number of wavelength range intervals 
         n = int(n)

--- a/sans/BILBY/BilbyCustomFunctions_Reduction.py
+++ b/sans/BILBY/BilbyCustomFunctions_Reduction.py
@@ -182,7 +182,7 @@ def wavelengh_slices(wavelength_intervals, binning_wavelength_ini, wav_delta):
         else:                                                                          # if reminder is greater than 0, to trancate the maximum wavelength in the range
             n = math.floor((wav2 - wav1)/wav_delta)
             max_wave_length = wav1 + n*wav_delta           
-            print(('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length))
+            print('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length)
 
         # number of wavelength range intervals 
         n = int(n)

--- a/sans/Bilby_old/BilbyCustomFunctions_Reduction.py
+++ b/sans/Bilby_old/BilbyCustomFunctions_Reduction.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.api import *
 from mantid.simpleapi import *
 import csv, math, sys
@@ -63,7 +64,7 @@ def evaluate_files_list(numbers):
     for number in numbers.split(","):
         if "-" in number:
             start, end = number.split("-")
-            nrs = range(int(start), int(end) + 1)
+            nrs = list(range(int(start), int(end) + 1))
             expanded.extend(nrs)
         else:
             expanded.append(int(number))
@@ -125,7 +126,7 @@ def AttenuationCorrection(att_pos, data_before_May_2016):
     """ Bilby has four attenuators; before May 2016 there were only two. Value of the attenuators are hard coded here and being used for the I(Q) scaling in Q1D """
 
     if (data_before_May_2016):
-        print "You stated data have been collected before May, 2016, i.e. using old attenuators. Please double check."
+        print("You stated data have been collected before May, 2016, i.e. using old attenuators. Please double check.")
         if (att_pos == 2.0 or att_pos == 4.0):
             #print "Wrong attenuators value; Either data have been collected after May, 2016, or something is wrong with hdf file"
             #sys.exit()
@@ -181,7 +182,7 @@ def wavelengh_slices(wavelength_intervals, binning_wavelength_ini, wav_delta):
         else:                                                                          # if reminder is greater than 0, to trancate the maximum wavelength in the range
             n = math.floor((wav2 - wav1)/wav_delta)
             max_wave_length = wav1 + n*wav_delta           
-            print ('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length)
+            print(('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length))
 
         # number of wavelength range intervals 
         n = int(n)

--- a/sans/Bilby_old/BilbyCustomFunctions_Reduction.py
+++ b/sans/Bilby_old/BilbyCustomFunctions_Reduction.py
@@ -182,7 +182,7 @@ def wavelengh_slices(wavelength_intervals, binning_wavelength_ini, wav_delta):
         else:                                                                          # if reminder is greater than 0, to trancate the maximum wavelength in the range
             n = math.floor((wav2 - wav1)/wav_delta)
             max_wave_length = wav1 + n*wav_delta           
-            print('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length))
+            print('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length)
 
         # number of wavelength range intervals 
         n = int(n)

--- a/sans/Bilby_old/BilbyCustomFunctions_Reduction.py
+++ b/sans/Bilby_old/BilbyCustomFunctions_Reduction.py
@@ -182,7 +182,7 @@ def wavelengh_slices(wavelength_intervals, binning_wavelength_ini, wav_delta):
         else:                                                                          # if reminder is greater than 0, to trancate the maximum wavelength in the range
             n = math.floor((wav2 - wav1)/wav_delta)
             max_wave_length = wav1 + n*wav_delta           
-            print(('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length))
+            print('\n WARNING: because of your set-up, maximum wavelength to consider for partial reduction is only %4.2f \n' %max_wave_length))
 
         # number of wavelength range intervals 
         n = int(n)

--- a/sans/Larmor/Larmor.py
+++ b/sans/Larmor/Larmor.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid.simpleapi import *
 from shutil import copyfile
 from math import *
@@ -32,13 +33,13 @@ def parseRunList(istring):
 						tstr[j].strip()
 						tstr2=tstr[j].split('-')
 						tstr3=tstr2[1].split(':')
-						r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+						r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
 						for k in r1:
 							rlist2.append(str(k))
 					elif tstr[j].find('-') >=0:
 						tstr[j].strip()
 						tstr2=tstr[j].split('-')
-						r1=range(int(tstr2[0]),int(tstr2[1])+1)
+						r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
 						for k in r1:
 							rlist2.append(str(k))
 					else:
@@ -48,13 +49,13 @@ def parseRunList(istring):
 					rlist1[i].strip()
 					tstr2=rlist1[i].split('-')
 					tstr3=tstr2[1].split(':')
-					r1=range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1]))
+					r1=list(range(int(tstr2[0]),int(tstr3[0])+1,int(tstr3[1])))
 					for k in r1:
 						rlist2.append(str(k))
 				elif rlist1[i].find('-')>=0:
 					rlist1[i].strip()
 					tstr2=rlist1[i].split('-')
-					r1=range(int(tstr2[0]),int(tstr2[1])+1)
+					r1=list(range(int(tstr2[0]),int(tstr2[1])+1))
 					for k in r1:
 						rlist2.append(str(k))
 				else:
@@ -71,7 +72,7 @@ def add_runs(runlist,pathout,instrument='LARMOR',keepwksp=0,savewksp=1,eventbinn
 		return
 	pfix=instrument
 	runlist=parseRunList(runlist)
-	print "runlist=",runlist
+	print("runlist=",runlist)
 	runlist=runlist[0]
 	Load(runlist[0],LoadMonitors='1',OutputWorkspace='added')
 	#print "          uampHr = ", added.getRun().getProtonCharge()
@@ -127,7 +128,7 @@ def add_runs(runlist,pathout,instrument='LARMOR',keepwksp=0,savewksp=1,eventbinn
 		fpad=""
 		for ii in range(nzeros):
 			fpad+="0"
-		print "writing file:   "+pathout+pfix+fpad+runlist[0]+"-add.nxs"
+		print("writing file:   "+pathout+pfix+fpad+runlist[0]+"-add.nxs")
 		SaveNexusProcessed("added",pathout+pfix+fpad+runlist[0]+"-add.nxs")
 		added=mtd['added']
 		#print "    total uampHr = ", added.getRun().getProtonCharge()
@@ -359,7 +360,7 @@ def virtualslitxml(ypos):
 def createMapFile(rnum,fname):
 	'''
 	Generate the mapfile required for create1DPSD
-	e.g. createMapFile(1203,'w:\Users\Masks\Integrate_tubes_map_file.xml')
+	e.g. createMapFile(1203,'w:\\Users\Masks\Integrate_tubes_map_file.xml')
 	'''
 	w1=Load(str(rnum))
 	calibrateTubes(w1,"")
@@ -380,13 +381,13 @@ def createMapFile(rnum,fname):
 		for j in range(len(detlist)-1):
 			s+=str(detlist[j])+','
 		s+=str(detlist[len(detlist)-1])+'"/> </group>\n'
-		print s
+		print(s)
 		f.write(s)
 	s='</detector-grouping>\n'
 	f.write(s)
 	f.close()
 
-def create1DPSD(rnum,lmin=0.8,lmax=13.0,Mapfile='w:\Users\Masks\Integrate_tubes_map_file.xml'):
+def create1DPSD(rnum,lmin=0.8,lmax=13.0,Mapfile='w:\\Users\Masks\Integrate_tubes_map_file.xml'):
 	'''
 	Sum the detector in horizontal stripes according to the setup within a mapfile
 	'''
@@ -462,7 +463,7 @@ def calculateDBFile(rsam,rcan,tsam,tdb,tcan,niterations,filepath,maskfilebase,DB
 		shl.copy(filepath+maskfilebase+'.txt',filepath+maskfilebase+str(i+1)+'.txt')
 		shl.copy(filepath+DBfilebase+'.dat',filepath+DBfilebase+'_v'+str(i+1)+'.dat')
 		for line in finp.input(filepath+maskfilebase+str(i+1)+'.txt',inplace=True):
-			print line.replace('MON/DIRECT='+DBfilebase+'.dat','MON/DIRECT='+DBfilebase+'_v'+str(i+1)+'.dat')
+			print(line.replace('MON/DIRECT='+DBfilebase+'.dat','MON/DIRECT='+DBfilebase+'_v'+str(i+1)+'.dat'))
 
 	#rsam="1761-add"
 	#rcan="1757-add"
@@ -561,7 +562,7 @@ def calculateDBFile(rsam,rcan,tsam,tdb,tcan,niterations,filepath,maskfilebase,DB
 			QA=Q2A+(1./wav2-1./W2)*(Q1A-Q2A)/(1./W1-1./W2)
 			QB=Q2B+(1./wav1-1./W2)*(Q1B-Q2B)/(1./W1-1./W2)
 			# ratio full wavelength data over chosen Q range
-			print wav1,wav2,QA,QB
+			print(wav1,wav2,QA,QB)
 			ratio='ratio_'+str(wav1)+'_'+str(wav2)
 			# NEW x3 lines, if the division falls over here it is usually beacuse you have empty workspace due to Bragg time masks
 			CropWorkspace(reducedAll,OutputWorkspace=ratio,Xmin=QA,Xmax=QB)
@@ -575,7 +576,7 @@ def calculateDBFile(rsam,rcan,tsam,tdb,tcan,niterations,filepath,maskfilebase,DB
 			QAA= mtd["integral"].readX(0)[0]
 			norm = mtd["integral"].readY(0)[0]/(QBB-QAA)
 			normE = mtd["integral"].readE(0)[0]/(QBB-QAA)
-			print QAA,QBB,norm,normE
+			print(QAA,QBB,norm,normE)
 			scaleX.append(wav1)
 			int=mtd["integral"].readY(0)[0]
 			scaleY.append(norm*(wav2-wav1))

--- a/sans/Larmor/SANSroutines.py
+++ b/sans/Larmor/SANSroutines.py
@@ -1,27 +1,28 @@
 #from genie import *
 #from genie_epics_api import *
+from __future__ import print_function
 import genie_python.genie as gen
 import genie_python.genie_epics_api as geapi
 
 # genie_epics_api is needed for set_sample_par amongst other things
 
 def dosans(size):
-    print "dosans"
+    print("dosans")
     setuplarmor_normal()
 
 def dotrans():
-    print "dotrans"
+    print("dotrans")
 
 def move():
-    print "moving sample"
+    print("moving sample")
 
     
 def do_hist_sans():
-    print "do_hist_sans"
+    print("do_hist_sans")
 
 def setuplarmor_scanning():
     gen.change(nperiods=1)
-    print "setup larmor scanning"
+    print("setup larmor scanning")
     gen.change_start()
     gen.change_tables(spectra="C:\Instrument\Settings\Tables\spectra_scanning_80.dat")
     gen.change_tables(wiring="C:\Instrument\Settings\Tables\wiring.dat")
@@ -30,7 +31,7 @@ def setuplarmor_scanning():
 
 def setuplarmor_nr():
     gen.change(nperiods=1)
-    print "setup larmor nr"
+    print("setup larmor nr")
     gen.change_start()
     gen.change_tables(spectra="C:\Instrument\Settings\Tables\spectra_nrscanning.dat")
     gen.change_tables(wiring="C:\Instrument\Settings\Tables\wiring.dat")
@@ -39,16 +40,16 @@ def setuplarmor_nr():
 
 def setuplarmor_nrscanning():
     gen.change(nperiods=1)
-    print "setup larmor nrscanning"
+    print("setup larmor nrscanning")
     gen.change_start()
     #change_tables(spectra="C:\Instrument\Settings\Tables\spectra_nrscanning.dat")
-    gen.change_tables(spectra="U:\Users\Masks\spectra_scanning_auto.dat")
+    gen.change_tables(spectra="U:\\Users\Masks\spectra_scanning_auto.dat")
     gen.change_tables(wiring="C:\Instrument\Settings\Tables\wiring.dat")
     gen.change_tcb(low=5.0,high=100000.0,step=100.0,trange=1)
     gen.change_finish()
 
 def setuplarmor_normal():
-    print "setup larmor normal"
+    print("setup larmor normal")
     gen.change(nperiods=1)
     gen.change_start()
     gen.change_tables(spectra="C:\Instrument\Settings\Tables\spectra_1To1.dat")
@@ -57,7 +58,7 @@ def setuplarmor_normal():
     gen.change_finish()
 
 def setuplarmor_polarised():
-    print "setup larmor polarised"
+    print("setup larmor polarised")
     gen.change(nperiods=1)
     gen.change_start()
     gen.change_tables(spectra="C:\Instrument\Settings\Tables\spectra_1To1.dat")
@@ -67,7 +68,7 @@ def setuplarmor_polarised():
 
 def setuplarmor_bsalignment():
     gen.change(nperiods=1)
-    print "setup larmor beamstop alignment"
+    print("setup larmor beamstop alignment")
     gen.change_start()
     gen.change_tables(spectra="C:\Instrument\Settings\Tables\spectra_1To1.dat")
     gen.change_tables(wiring="C:\Instrument\Settings\Tables\wiring.dat")
@@ -76,7 +77,7 @@ def setuplarmor_bsalignment():
 
 def setuplarmor_monitorsonly():
     gen.change(nperiods=1)
-    print "setup larmor monitors only"
+    print("setup larmor monitors only")
     gen.change_start()
     gen.change_tables(spectra="C:\Instrument\Settings\Tables\spectra_phase1.dat")
     gen.change_tables(wiring="C:\Instrument\Settings\Tables\wiring.dat")
@@ -85,7 +86,7 @@ def setuplarmor_monitorsonly():
 
 def setuplarmor_event():
     gen.change(nperiods=1)
-    print "setup larmor for event mode"
+    print("setup larmor for event mode")
     gen.change_start()
     gen.change_tables(spectra="C:\Instrument\Settings\Tables\spectra_1To1.dat")
     gen.change_tables(wiring="C:\Instrument\Settings\Tables\wiring_event.dat")
@@ -94,7 +95,7 @@ def setuplarmor_event():
 
 def setuplarmor_4periods():
     gen.change(nperiods=1)
-    print "setup larmor for 4 Period mode"
+    print("setup larmor for 4 Period mode")
     gen.change_start()
     gen.change_tables(spectra="C:\Instrument\Settings\Tables\spectra_4To1.dat")
     gen.change_tables(wiring="C:\Instrument\Settings\Tables\wiring.dat")
@@ -102,7 +103,7 @@ def setuplarmor_4periods():
     gen.change_finish()
 
 def setuplarmor_quiet():
-    print "setup larmor quiet"
+    print("setup larmor quiet")
 
 def FOMin():
     cset(pol_trans=110,pol_arc=-1.6)
@@ -114,7 +115,7 @@ def LongPolariserin():
     cset(pol_trans=209,pol_arc=-1.6)
     
 def homecoarsejaws():
-    print "Homing Coarse Jaws"
+    print("Homing Coarse Jaws")
     gen.cset(cjhgap=40,cjvgap=40)
     gen.waitfor_move()
     # home north and west
@@ -132,13 +133,13 @@ def homecoarsejaws():
     
 
 def homea1():
-    print "Homing a1"
+    print("Homing a1")
 
 def homes1():
-    print "Homing s1"
+    print("Homing s1")
 
 def homes2():
-    print "Homing s2"
+    print("Homing s2")
 
 def detectoronoff(onoff=0,delay=1):
     if(onoff==1):
@@ -154,15 +155,15 @@ def detectoronoff(onoff=0,delay=1):
     # wait for 3 minutes for ramp up 60s to ranmp down
     if(delay==1):
         if(onoff==1):
-            print "Waiting For Detector To Power Up (180s)"
+            print("Waiting For Detector To Power Up (180s)")
             sleep(180)
         else:
-            print "Waiting For Detector To Power Down (60s)"
+            print("Waiting For Detector To Power Down (60s)")
             sleep(60)
             
 
 def movebench(angle=0.0,delaydet=1):
-    print "Turning Detector Off"
+    print("Turning Detector Off")
     detectoronoff(onoff=0,delay=delaydet)
     a1=0
     a1+=gen.get_pv("IN:LARMOR:CAEN:hv0:0:8:status")
@@ -170,30 +171,30 @@ def movebench(angle=0.0,delaydet=1):
     a1+=gen.get_pv("IN:LARMOR:CAEN:hv0:0:10:status")
     a1+=gen.get_pv("IN:LARMOR:CAEN:hv0:0:11:status")
     if(a1>0):
-        print "The detector is not turned off"
-        print "Not attempting Move"
+        print("The detector is not turned off")
+        print("Not attempting Move")
         return
     else:
-        print "The detector is off"
+        print("The detector is off")
        
     if(angle >= 0.0):
         gen.cset(benchlift=1)
-        print "Lifting Bench (20s)"
+        print("Lifting Bench (20s)")
         sleep(20)
         a1=gen.get_pv("IN:LARMOR:BENCH:STATUS")
 
         if(a1==1):
-            print "Rotating Bench"
+            print("Rotating Bench")
             gen.cset(bench_rot=angle)
             waitfor_move()
-            print "Lowering Bench (20s)"
+            print("Lowering Bench (20s)")
             gen.cset(benchlift=0)
             sleep(20)
         else:
-            print "Bench failed to lift"
-            print "Move not attempted"
+            print("Bench failed to lift")
+            print("Move not attempted")
     #turn the detector back on
-    print "Turning Detector Back on"
+    print("Turning Detector Back on")
     detectoronoff(onoff=1,delay=delaydet)
 
 def rotatebench(angle=0.0,delaydet=1):
@@ -203,26 +204,26 @@ def rotatebench(angle=0.0,delaydet=1):
     a1+=gen.get_pv("IN:LARMOR:CAEN:hv0:0:10:status")
     a1+=gen.get_pv("IN:LARMOR:CAEN:hv0:0:11:status")
     if(a1>0):
-        print "The detector is not turned off"
-        print "Not attempting Move"
+        print("The detector is not turned off")
+        print("Not attempting Move")
         return
     else:
-        print "The detector is off"
+        print("The detector is off")
        
     if(angle >= -0.5):
         gen.cset(benchlift=1)
-        print "Lifting Bench (20s)"
+        print("Lifting Bench (20s)")
         sleep(20)
         a1=gen.get_pv("IN:LARMOR:BENCH:STATUS")
 
         if(a1==1):
-            print "Rotating Bench"
+            print("Rotating Bench")
             gen.cset(bench_rot=angle)
             waitfor_move()
-            print "Lowering Bench (20s)"
+            print("Lowering Bench (20s)")
             gen.cset(benchlift=0)
             sleep(20)
         else:
-            print "Bench failed to lift"
-            print "Move not attempted"
+            print("Bench failed to lift")
+            print("Move not attempted")
 

--- a/sans/Larmor/Semsans/GetLog.py
+++ b/sans/Larmor/Semsans/GetLog.py
@@ -5,7 +5,7 @@ import datetime
 import numpy as np
 import re
 import xml.etree.cElementTree
-from runtypes import QuickData, RunData
+from .runtypes import QuickData, RunData
 
 class GetLog(PythonAlgorithm):
 
@@ -97,7 +97,7 @@ class GetLog(PythonAlgorithm):
 
         d = {}
         for run in temp:
-            if run.sample in d.keys():
+            if run.sample in list(d.keys()):
                 d[run.sample].append(run)
             else:
                 d[run.sample] = [run]
@@ -112,7 +112,7 @@ class GetLog(PythonAlgorithm):
         my_table.addColumn("int", "Can Trans run")
         my_table.addColumn("int", "Direct Trans run")
 
-        for k, v in d.items():
+        for k, v in list(d.items()):
             for run in v:
                 my_table.addRow(
                     [run.number, run.sample,
@@ -124,7 +124,7 @@ class GetLog(PythonAlgorithm):
 
         my_table = WorkspaceFactory.createTable()
         my_table.addColumn("str", "Name")
-        for k, _ in d.items():
+        for k, _ in list(d.items()):
             my_table.addRow([k])
         self.setProperty("SamplesTable", my_table)
 

--- a/sans/Larmor/Semsans/metadata.py
+++ b/sans/Larmor/Semsans/metadata.py
@@ -227,12 +227,12 @@ def get_log(runs):
 
     d = {}
     for run in temp:
-        if run.sample in d.keys():
+        if run.sample in list(d.keys()):
             d[run.sample].append(run)
         else:
             d[run.sample] = [run]
 
-    for k, v in d.items():
+    for k, v in list(d.items()):
         my_table = CreateEmptyTableWorkspace()
         my_table.addColumn("int", "Run Number")
         my_table.addColumn("str", "Sample")

--- a/sans/Larmor/Simple_Scan.py
+++ b/sans/Larmor/Simple_Scan.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from matplotlib.pyplot import errorbar, plot, show
 import numpy as np
 import SANSroutines as lm
@@ -76,7 +77,7 @@ def scan_axis(axis,startval,endval,npoints,frms,rtitle,usem4=0):
         a1=gen.get_spectrum(1,i+1)
         msig=sum(a1['signal'])*100.0
         mesig=(math.sqrt(msig))
-        print "msig="+str(msig)+" mesig="+str(mesig)
+        print("msig="+str(msig)+" mesig="+str(mesig))
         # get the interesting monitor
         if usem4 < 1:
             a1=gen.get_spectrum(11,i+1)
@@ -88,10 +89,10 @@ def scan_axis(axis,startval,endval,npoints,frms,rtitle,usem4=0):
             a1=gen.get_spectrum(4,i+1)
             sig=sum(a1['signal'])*100.0
             esig=math.sqrt(sig)
-        print "sig="+str(sig)+" esig="+str(esig)
+        print("sig="+str(sig)+" esig="+str(esig))
         yval[i]=(sig/msig)
         eval[i]=(math.sqrt((sig/(msig*msig))+(sig*sig/(msig*msig*msig))))
-        print "yval="+str(yval[i])+" esig="+str(eval[i])
+        print("yval="+str(yval[i])+" esig="+str(eval[i]))
         ax.errorbar(xval[i], yval[i], eval[i], fmt = 'ko')
         fig1.canvas.draw()
         mpl.pause(0.001)
@@ -164,7 +165,7 @@ def scan_axis_mantid(axis,startval,endval,npoints,frms,rtitle,usem4=0):
         a1=gen.get_spectrum(1,i+1)
         msig=sum(a1['signal'])*100.0
         mesig=(math.sqrt(msig))
-        print "msig="+str(msig)+" mesig="+str(mesig)
+        print("msig="+str(msig)+" mesig="+str(mesig))
         # get the interesting monitor
         if usem4 < 1:
             a1=gen.get_spectrum(11,i+1)
@@ -176,10 +177,10 @@ def scan_axis_mantid(axis,startval,endval,npoints,frms,rtitle,usem4=0):
             a1=gen.get_spectrum(4,i+1)
             sig=sum(a1['signal'])*100.0
             esig=math.sqrt(sig)
-        print "sig="+str(sig)+" esig="+str(esig)
+        print("sig="+str(sig)+" esig="+str(esig))
         yval[i]=(sig/msig)
         eval[i]=(math.sqrt((sig/(msig*msig))+(sig*sig/(msig*msig*msig))))
-        print "yval="+str(yval[i])+" esig="+str(eval[i])
+        print("yval="+str(yval[i])+" esig="+str(eval[i]))
         gui_cmd(ax.errorbar,xval[i], yval[i], eval[i], fmt = 'ko')
         gui_cmd(fig1.canvas.draw)
         gui_cmd(mpl.pause,0.001)

--- a/sans/rkh_scripts/SANSuseful26_varifocal_6m_gdw_BKG_singleMask.py
+++ b/sans/rkh_scripts/SANSuseful26_varifocal_6m_gdw_BKG_singleMask.py
@@ -5,6 +5,7 @@
 # 17/12/12 this for GDW at 4m WITH FLAT BKG SUBTRACTION, fit to trans is OFF,, this one integrates RATIOS of I(Q)
 # Q ranges for ratios also expanded to suit the large detector X offset on this data set.
 #Make the reduction module available
+from __future__ import print_function
 from ISISCommandInterface import *
 # NEW
 from mantid.simpleapi import *
@@ -153,7 +154,7 @@ for ii in range(nIterations):
 	#	normE = mtd["integral"].readE(0)[0]
 	#	print wav1,wav2,QA,QB,norm,normE
 	# ratio full wavelength data over chosen Q range
-		print wav1,wav2,QA,QB
+		print(wav1,wav2,QA,QB)
 		ratio='ratio_'+str(wav1)+'_'+str(wav2)
 	# NEW x3 lines
 		CropWorkspace(reducedAll,OutputWorkspace=ratio,Xmin=QA,Xmax=QB)
@@ -167,7 +168,7 @@ for ii in range(nIterations):
 		QAA= mtd["integral"].readX(0)[0]
 		norm = mtd["integral"].readY(0)[0]/(QBB-QAA)
 		normE = mtd["integral"].readE(0)[0]/(QBB-QAA)
-		print QAA,QBB,norm,normE
+		print(QAA,QBB,norm,normE)
 		scaleX.append(wav1)
 		int=mtd["integral"].readY(0)[0]
 		scaleY.append(norm*(wav2-wav1))
@@ -206,7 +207,7 @@ for ii in range(nIterations):
 	next=next+1
 	i=i+1
 	#====================================================================================================
-print "Last iteration of new direct beam file was "+newdirectfile
+print("Last iteration of new direct beam file was "+newdirectfile)
 #====================================================================================================
 #
 #  add results of loop to original plot
@@ -238,7 +239,7 @@ det = wksp.getDetector(11000)
 # then check the coords for the shift 
 out=str(det.getPos())
 # NEED to read X&Y coords from string "out" here 
-print "det is  "+out 
+print("det is  "+out) 
 #
 #
 # D_H or D_V  sums, need get these into a gui
@@ -313,7 +314,7 @@ Integration("D_T_LOQ","D_LOQ_integral",3500,43500)
 #
 import sys
 sys.path.append("C:/Mantidinstall/scripts/SANS")
-print sys.path
+print(sys.path)
 import SANSUtility
 # D_T for nine blocks when dae playing up  in cycle 09/1 or 09/2
 wksp="SANS2D00001674"
@@ -328,14 +329,14 @@ i=0
 namelist=["A TL","D TC","G TR","B ML","E MC","H MR","C BL","F BC","I BR"]
 masklist=["h0>h127,v64>v191","h0>h127,v0>v63,v128>v191","h0>h127,v0>v127","h0>h63,h128>h191,v64>v191","h0>h63,h128>h191,v0>v63,v128>v191","h0>h63,h128>h191,v0>v127","h63>h191,v64>v191","h63>h191,v0>v63,v128>v191","h63>h191,v0>v127"]
 for name in namelist:
-	print "i= "+str(i)
+	print("i= "+str(i))
 	# guess "orientation"
 	list = SANSUtility.ConvertToSpecList(masklist[i], spec1, dimdet,'0')
 	CropWorkspace(wksp, OutputWorkspace = "D_T "+name+tag, StartWorkspaceIndex=(spec1-1), EndWorkspaceIndex=str(spec1+192*192-2))
 	SANSUtility.MaskBySpecNumber("D_T "+name+tag, list)
 	SumSpectra("D_T "+name+tag,"D_T "+name+tag)
 	i=i+1
-print "done"
+print("done")
 for wext in namelist:
 	wsp="D_T "+wext
 	if wext==namelist[0]:
@@ -377,11 +378,11 @@ file=reduced.split('_')
 # BUG here if we have not actually run the full range of WLIST
 first = file[0]+'_'+str(wlist[0])+'_'+str(wlist[len(wlist)-1])
 # need to see if "first" exists, else then use outlist[0] ?
-print first
+print(first)
 plt = plotSpectrum(first, 0)
 layer=plt.activeLayer()
 layer.setTitle(file[0])
-print i
+print(i)
 #print outlist[6]
 #
 for i in range(len(outlist)):
@@ -394,6 +395,6 @@ SaveRKH(first,filename,Append='0')
 # now save all the partial ranges to file
 for i in range(len(outlist)):
 	SaveRKH(outlist[i],filename,Append='1')
-print "Written to "+filename
+print("Written to "+filename)
 #
 #

--- a/user/ExampleUser/PlotAsymmetryByLogValue_Example.py
+++ b/user/ExampleUser/PlotAsymmetryByLogValue_Example.py
@@ -16,6 +16,6 @@ if int(alg.getPropertyValue("Green")) < 1000:
     spectra_plot[2] = 'Green'
     spectra_plot[3] = 'Sum'
 
-gs = plotSpectrum(ws, spectra_plot.keys())
-for key, value in spectra_plot.iteritems():
+gs = plotSpectrum(ws, list(spectra_plot.keys()))
+for key, value in spectra_plot.items():
     gs.activeLayer().setCurveTitle(key, value)

--- a/user/ExampleUser/SampleLogs_Demo.py
+++ b/user/ExampleUser/SampleLogs_Demo.py
@@ -1,6 +1,7 @@
 #
 # Example: Retrieving log information from a data set
 #
+from __future__ import print_function
 
 datadir = "../../../repo/Test/Data/"
 rawDataTitle="outputSpace"
@@ -16,8 +17,8 @@ logs = rawWS.getRun().getLogData()
 
 # Print all of the log information
 for i in range(0, len(logs)):
-	print "----- " + logs[i].name + " -------\n" +  str(logs[i].value)
+	print("----- " + logs[i].name + " -------\n" +  str(logs[i].value))
 
 # Just get a single log by name
 status = rawWS.getRun().getLogData("status")
-print status.value
+print(status.value)

--- a/user/ExampleUser/SimpleMtdCommands_Example.py
+++ b/user/ExampleUser/SimpleMtdCommands_Example.py
@@ -1,6 +1,7 @@
 #
 # Example: Basic Mantid commands
 #
+from __future__ import print_function
 
 # Print the available algorithms
 mtdHelp()
@@ -20,5 +21,5 @@ DeleteWorkspace("converted")
 # extract the one we want
 wksp = mtd['rebinned']
 
-print "Rebinned workspace has " + str(wksp.getNumberHistograms()) + " histograms"
-print "Spectrum 450's X data size = " + str(len(wksp.readX(450))) + " bin boundaries"
+print("Rebinned workspace has " + str(wksp.getNumberHistograms()) + " histograms")
+print("Spectrum 450's X data size = " + str(len(wksp.readX(450))) + " bin boundaries")

--- a/user/ExampleUser/SolidAngle_Example.py
+++ b/user/ExampleUser/SolidAngle_Example.py
@@ -4,6 +4,7 @@
 ##          sample position
 ##
 ##-------------------------------------------------------------------------
+from __future__ import print_function
 import math
 # Prompt for a raw file to load
 rawWSTitle = "RawFile"
@@ -26,12 +27,12 @@ r = detector.getDistance(sample)
 twoTheta = detector.getTwoTheta(samplePos, beamPos)*180./math.pi
 phi = detector.getPhi()
 
-print 'R = ' + str(r) + ', TwoTheta = ' + str(twoTheta)+ ', Phi = ' + str(phi)
+print('R = ' + str(r) + ', TwoTheta = ' + str(twoTheta)+ ', Phi = ' + str(phi))
 
 # Check if the detector is masked out and calculate the result if not
 solidAngle = 0.0
 if not detector.isMasked():
     sAngle = detector.solidAngle(samplePos)
 
-print "The solid angle of the spectrum located at index " + str(wsIndex) + " is: " + str(sAngle) + " steradians"
+print("The solid angle of the spectrum located at index " + str(wsIndex) + " is: " + str(sAngle) + " steradians")
 

--- a/user/ExampleUser/StripPeaks.py
+++ b/user/ExampleUser/StripPeaks.py
@@ -2,6 +2,7 @@
 #
 # Using StripPeaks + dialog boxes
 #
+from __future__ import print_function
 
 LoadRawDialog(OutputWorkspace="GEM40979")
 alg= AlignDetectorsDialog("GEM40979",OutputWorkspace="aligned")
@@ -16,4 +17,4 @@ g1 = plotSpectrum(["focussed","stripped"],5)
 
 # Rescale the x-axis to show an interesting region
 g1.activeLayer().setScale(Layer.Bottom,0,2.3)
-print "Done!"
+print("Done!")

--- a/user/ExampleUser/TableWorkspace_Example.py
+++ b/user/ExampleUser/TableWorkspace_Example.py
@@ -1,4 +1,5 @@
 # Perform some algorithms
+from __future__ import print_function
 LoadRaw(Filename="GEM40979.raw",OutputWorkspace="GEM40979")
 AlignDetectors("GEM40979",OutputWorkspace="aligned",CalibrationFile="offsets_2006_cycle064.cal")
 DeleteWorkspace("GEM40979")
@@ -8,13 +9,13 @@ FindPeaks("focussed",PeaksList="peakslist")
 
 peaks = mtd["peakslist"]
 help(peaks)
-print "Number of Columns: " + str(peaks.columnCount()) + " , Number of rows: "+ str(peaks.rowCount())
+print("Number of Columns: " + str(peaks.columnCount()) + " , Number of rows: "+ str(peaks.rowCount()))
 
 colNames = peaks.getColumnNames()
 for i in colNames:
-	print i
+	print(i)
 
 for i in range(peaks.rowCount()):
 	row = peaks.row(i)
-	print "Spectrum %d has peak at pos %f" % (row['spectrum'], row['centre'])
+	print("Spectrum %d has peak at pos %f" % (row['spectrum'], row['centre']))
 

--- a/user/ExampleUser/test_upload.py
+++ b/user/ExampleUser/test_upload.py
@@ -2,4 +2,5 @@
 
 This is a full summary of the module
 """
-print "Hello, World"
+from __future__ import print_function
+print("Hello, World")

--- a/user/NickDraper/test script 2 copy.py
+++ b/user/NickDraper/test script 2 copy.py
@@ -1,1 +1,2 @@
-from __future__ import print_function)print("hi there")
+from __future__ import print_function)
+print("hi there")

--- a/user/NickDraper/test script 2 copy.py
+++ b/user/NickDraper/test script 2 copy.py
@@ -1,1 +1,1 @@
-print "hi there"
+from __future__ import print_function)print("hi there")

--- a/user/NickDraper/test script 2.py
+++ b/user/NickDraper/test script 2.py
@@ -1,1 +1,1 @@
-print "hi"
+from __future__ import print_function)print("hi")

--- a/user/NickDraper/test script 2.py
+++ b/user/NickDraper/test script 2.py
@@ -1,1 +1,2 @@
-from __future__ import print_function)print("hi")
+from __future__ import print_function)
+print("hi")

--- a/user/NickDraper/test script.py
+++ b/user/NickDraper/test script.py
@@ -1,1 +1,2 @@
-from __future__ import print_function)print("hi there")
+from __future__ import print_function)
+print("hi there")

--- a/user/NickDraper/test script.py
+++ b/user/NickDraper/test script.py
@@ -1,1 +1,1 @@
-print "hi there"
+from __future__ import print_function)print("hi there")

--- a/user/Polarisation/GUI/FunctionalMAGGOT.py
+++ b/user/Polarisation/GUI/FunctionalMAGGOT.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from PyQt4 import QtCore, QtGui
 import os
 from mantidsimple import *
@@ -639,7 +640,7 @@ class Ui_MAGGOTWindow(object):
 		PathandName = dialog.getOpenFileName(caption='Select NMR Files',directory=r'C:/')
 	#Extracts File Path
 	for i in range(1,len(PathandName)):
-		if PathandName[len(PathandName)-i] <> '/' :
+		if PathandName[len(PathandName)-i] != '/' :
 			PathandName=PathandName
 		else:
 			break
@@ -647,7 +648,7 @@ class Ui_MAGGOTWindow(object):
 	filepath=PathandName[0:(len(PathandName)-i+1)]
 	#Extracts File Name
 	for j in range(1,len(PathandName)):
-		if PathandName[len(PathandName)-j] <> '_' :
+		if PathandName[len(PathandName)-j] != '_' :
 			PathandName=PathandName
 		else:
 			break
@@ -667,7 +668,7 @@ class Ui_MAGGOTWindow(object):
 		PathandName = dialog.getOpenFileName(caption='Select NMR Files',directory=r'C:/')
 	#Extracts File Path
 	for i in range(1,len(PathandName)):
-		if PathandName[len(PathandName)-i] <> '/' :
+		if PathandName[len(PathandName)-i] != '/' :
 			PathandName=PathandName
 		else:
 			break
@@ -675,7 +676,7 @@ class Ui_MAGGOTWindow(object):
 	filepath=PathandName[0:(len(PathandName)-i+1)]
 	#Extracts File Name
 	for j in range(1,len(PathandName)):
-		if PathandName[len(PathandName)-j] <> '_' :
+		if PathandName[len(PathandName)-j] != '_' :
 			PathandName=PathandName
 		else:
 			break
@@ -773,9 +774,9 @@ class Ui_MAGGOTWindow(object):
 ##error if no files fit or all files fitted
 	except:
 		if i == n0:
-			print 'Error: Initial filepath incorrect.'
+			print('Error: Initial filepath incorrect.')
 		elif n0 < i <= n+1 :
-			print 'All NMR files fitted.'
+			print('All NMR files fitted.')
 ##close params file
 	NMRDIAG.close()
 	A_NMR.close()		
@@ -848,33 +849,33 @@ class Ui_MAGGOTWindow(object):
 			LoadAscii(Filename=Filepath+PreFile+str(i),OutputWorkspace=PreFile)
 			Fit(Function='name=UserFunction,Formula=A*exp(-(x/T2))*cos(2*'+str(pi)+'*(f*x+p)),A=0.0004,T2=0.1,f='+str(Frequency)+'.0,p=0.000000',InputWorkspace=PreFile  ,Output=PreFile+'res',StartX='0.002',EndX='0.19999',CalcErrors=True)
 			table = mtd[str(PreFile)+'res_Parameters']	
-			print 'Amplitude is ' + str(abs(table.cell(0,1))) + ' mV.'	
+			print('Amplitude is ' + str(abs(table.cell(0,1))) + ' mV.')	
 			PreSum=PreSum+abs(table.cell(0,1))
 		
 	except: 
 		if i==1:
-			print 'Error: only 1 PreFile attempted'
+			print('Error: only 1 PreFile attempted')
 		else: 
 			#print i
-			print PreSum
+			print(PreSum)
 			PreAverage = float(PreSum)/(float(i-1))
-			print PreAverage
+			print(PreAverage)
 
 	try:
 		for i in range (1, (1000)):	
 			LoadAscii(Filename=Filepath+PostFile+str(i),OutputWorkspace=PostFile)
 			Fit(Function='name=UserFunction,Formula=A*exp(-(x/T2))*cos(2*'+str(pi)+'*(f*x+p)),A=0.0004,T2=0.1,f='+str(Frequency)+'.0,p=0.000000',InputWorkspace=PostFile  ,Output=PostFile+'res',StartX='0.002',EndX='0.19999',CalcErrors=True)
 			table = mtd[str(PostFile)+'res_Parameters']
-			print 'Amplitude is ' + str(abs(table.cell(0,1))) + ' mV.'
+			print('Amplitude is ' + str(abs(table.cell(0,1))) + ' mV.')
 			PostSum=PostSum+abs(table.cell(0,1))
 	except:
 		if i==1:
-			print 'Error: only 1 PostFile attempted'
+			print('Error: only 1 PostFile attempted')
 		else:
 			#print i
-			print PostSum
+			print(PostSum)
 			PostAverage = float(PostSum)/(float(i-1))
-			print PostAverage
+			print(PostAverage)
 	
 	if self.Use_LPP.isChecked() == True : 
 		try: 
@@ -888,8 +889,8 @@ class Ui_MAGGOTWindow(object):
 					p=p
 		except: 
 			if i==1:
-				print 'Error: only 1 PreFile attempted'
-		print 'p from first is '+str(p)
+				print('Error: only 1 PreFile attempted')
+		print('p from first is '+str(p))
 		try:
 			for i in range (1, 1000):
 				LoadAscii(Filename=Filepath+PostFile+str(i),OutputWorkspace=PostFile)
@@ -901,12 +902,12 @@ class Ui_MAGGOTWindow(object):
 					p=p
 		except: 
 			if i==1:
-				print 'Error: only 1 PostFile attempted'
-		print 'p from second is '+str(p)
+				print('Error: only 1 PostFile attempted')
+		print('p from second is '+str(p))
 	else: 
 		p=0
 		
 	
 	F=((1/(float(1-self.LPP_Value.value())**float(p)))*((float(PostSum))/(float(PreSum))))**(1/float(self.LPF_FinalNMR.value()))
-	print 'Loss per flip is ' +str(1-F)
+	print('Loss per flip is ' +str(1-F))
 	self.LPF_Result.setText(str(1-F))

--- a/user/Polarisation/Optimum time calculator.py
+++ b/user/Polarisation/Optimum time calculator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from numpy import *
 from pylab import *
 
@@ -40,7 +41,7 @@ gui_cmd(plot,t,DS)
 ##find optimum time(point of intersect)
 DS0=-a-Tup*log(1-(1/(nl*lmda*Pol))*arccosh((cosh(nl*lmda*Pol*(1-exp(-a/Tup)))+cosh(nl*lmda*Pol*(1-exp(-(a+r)/Tup)))+4*cosh(nl*lmda*Pol*(1-exp(-(2*a+r)/(2*Tup)))) )/6 ))
 
-print 'Optimum time for this wavelength is '+str(DS0)+' hours'
+print('Optimum time for this wavelength is '+str(DS0)+' hours')
 
 ##create wavelength error graph
 x=arange(0,15.05,0.05)

--- a/user/Polarisation/Polariser Polarisation.py
+++ b/user/Polarisation/Polariser Polarisation.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from numpy import *
 import time
 units=1   #1 for hours, 60 for minutes, 3600 for secs
@@ -26,7 +27,7 @@ A_NPol= open(r'\\Britannic\3he\NMR\1 Current NMR Data\1Extracted Fit Data\\A_NPo
 
 ##Open files,normalise to current
 for i in range(8893,8922+1):
-	print i
+	print(i)
 	Load(Filename=r'\\britannic\3He\LET Data\0213\LET0000'+str(i)+'.raw',OutputWorkspace='Filei',SpectrumList='40966')
 	try:
 		NormaliseByCurrent(InputWorkspace='Filei',OutputWorkspace='Filei')

--- a/user/Polarisation/Simultaneous Polariser Analyser Calculator.py
+++ b/user/Polarisation/Simultaneous Polariser Analyser Calculator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from numpy import *
 import time
 #Opacity value needs to be changed in function for different cells
@@ -54,7 +55,7 @@ diagPol=open(r'\\Britannic\3he\NMR\1 Current NMR Data\1Extracted Fit Data\\diagP
 diagAna=open(r'\\Britannic\3he\NMR\1 Current NMR Data\1Extracted Fit Data\\diagAna.csv', 'w')
 ##Load file and apply mask
 for i in range(Initial_File,Final_File+1):
-	print i
+	print(i)
 	LoadRaw(Filename=r'\\isis\inst$\ndxlet\instrument\data\cycle_12_5\LET0000'+str(i)+'.raw',OutputWorkspace='filei')
 	MaskDetectors(Workspace='filei',MaskedWorkspace='MaskWorkspace')
 	try:


### PR DESCRIPTION
Subset of files in repository for which the changes by 2to3.py script are judged to be minor and low-risk (mostly print functions, range -> list(range) and similar for dict.keys() etc. and some maps have been replaced with list comprehension). In addition I have added a line to import print_function (removed by 2to3.py) to maintain python 2 compatibility. I did this with a script which adds the line to the top of the file (after the first block of comments if present). Note in some cases there are blank lines between comments at the top of the file and so it might not be added where the other imports are.

A code-check has been performed to check the files will run in python 2 and 3 - but this has not been tested.

To test:
(1) Review the code changes
(2)  Test a subset of the scripts to confirm they run in python 2 and 3.
 
In some cases the script may depend on another script for which I haven't committed the changes from python 2 to 3 as they are less trivial/I am not sure they will work. A spreadsheet with a list of files not committed and the reason are attached.

[Python3_mantidScriptRepo.xlsx](https://github.com/mantidproject/scriptrepository/files/3851663/Python3_mantidScriptRepo.xlsx)