### PR TITLE
Further manual changes for 2/3 compatibility

### DIFF
--- a/SingleCrystal/anvred3.py
+++ b/SingleCrystal/anvred3.py
@@ -116,7 +116,7 @@ from readSpecCoef import *
 from spectrumCalc import *
 from absor_sphere import *
 
-if sys.version_info > (3,0):
+if sys.version_info > (3,):
     from tkinter import *
     import tkinter.simpledialog as tkSimpleDialog
 else:

--- a/SingleCrystal/anvred3.py
+++ b/SingleCrystal/anvred3.py
@@ -98,6 +98,7 @@
 # !
 # !	4/13/09	Number of possible spectra increased from 2 to 100.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+from __future__ import print_function
 
 import os
 import sys
@@ -115,8 +116,12 @@ from readSpecCoef import *
 from spectrumCalc import *
 from absor_sphere import *
 
-from Tkinter import *
-import tkSimpleDialog
+if sys.version_info > (3,0):
+    from tkinter import *
+    import tkinter.simpledialog as tkSimpleDialog
+else:
+    from Tkinter import *
+    import tkSimpleDialog
  
 class MyDialog(tkSimpleDialog.Dialog):
 
@@ -358,12 +363,12 @@ TOPAZ_or_MaNDi = d.result[16]
 
 # Check that one of the two absorption correction types has been selected
 if abs_correc_type != 'spherical' and abs_correc_type != 'polyhedral':
-    print ''
-    print '**********************************************************'
-    print "Absorption correction type is not 'spherical' or 'polyhedral'."
-    print 'Check your spelling.'
-    print '**********************************************************'
-    print ''
+    print('')
+    print('**********************************************************')
+    print("Absorption correction type is not 'spherical' or 'polyhedral'.")
+    print('Check your spelling.')
+    print('**********************************************************')
+    print('')
     exit()
 
 # Write or over-write anvred3.inp file
@@ -379,20 +384,20 @@ if True:
 
     # Initialize UB_IPNS matrix
     UB_IPNS = numpy.zeros((3,3))
-    print '\n Input from matrix file ' + ub_matrix_file + ':\n'
+    print('\n Input from matrix file ' + ub_matrix_file + ':\n')
 
     # Read matrix file into UB_IPNS matrix
     for i in range(3):
         linestring = UB_input.readline()
-        print linestring.strip('\n')
+        print(linestring.strip('\n'))
         linelist = linestring.split()
         for j in range(3):
             UB_IPNS[i,j] = float(linelist[j])           
     # Read next 2 lines containing lattice constants and esd's
     for i in range(2):
         linestring = UB_input.readline()
-        print linestring.strip('\n')
-    print '\n'
+        print(linestring.strip('\n'))
+    print('\n')
     # End of reading and printing matrix file
                 
 # TOPAZ detector scale factors for vanadium/niobium spectrum
@@ -471,7 +476,7 @@ calibParam = readrefl_header( integFile )
 L1 = float(calibParam[0])       # initial flight path length in cm
 t0_shift = float(calibParam[1]) # t-zero offest in microseconds
 nod = int(calibParam[2])    # number of detectors
-print '********** nod = ', nod
+print('********** nod = ', nod)
 
 logFile.write('\nInitial flight path length: %10.4f cm' % L1 )
 logFile.write('\nT-zero offset: %8.3f microseconds' % t0_shift )
@@ -510,7 +515,7 @@ if iSpec == 0:
         time = []
         counts = []
         
-        print 'Reading spectrum for ' + lineString[0:-1]
+        print('Reading spectrum for ' + lineString[0:-1])
         while True:
             lineString = specInput.readline()
             lineList = lineString.split()
@@ -553,7 +558,7 @@ for id in range(nod):
         spect = spectx[0]            # the spectral normalization parameter
         relSigSpect = spectx[1]      # the relative sigma of spect
         if spect == 0.0:
-            print '*** Wavelength for normalizing to spectrum is out of range.'
+            print('*** Wavelength for normalizing to spectrum is out of range.')
         spect1.append(spect)
                           
 # C-----------------------------------------------------------------------
@@ -609,7 +614,7 @@ while True:
     sigi = abs(peak[20])
     reflag = peak[21]
     
-    if seqnum % 1000 == 0: print 'seqnum =', seqnum
+    if seqnum % 1000 == 0: print('seqnum =', seqnum)
     
 
     # set-up for new run or detector
@@ -847,17 +852,17 @@ while True:
     if fsq > fsqmax: fsqmax = fsq        
             
 if abs_correc_type == 'spherical':
-    print '\nMinimum and maximum transmission = %6.4f, %6.4f' % (transmin, transmax)
+    print('\nMinimum and maximum transmission = %6.4f, %6.4f' % (transmin, transmax))
 
 logFile.write('\n\n***** Minimum and maximum transmission = %6.4f, %6.4f' \
     % (transmin, transmax))
     
 if fsqmax > (10000.00 -1):
-    print
-    print '################################################################'
-    print '     Maximum FOSQ is', fsqmax
-    print '     Re-run anvred with a scale factor of', 0.1*scaleFactor
-    print '################################################################'
+    print()
+    print('################################################################')
+    print('     Maximum FOSQ is', fsqmax)
+    print('     Re-run anvred with a scale factor of', 0.1*scaleFactor)
+    print('################################################################')
 
 # last record all zeros for shelx
 iz = 0
@@ -916,7 +921,7 @@ if iIQ == 1 or iIQ == 3:
 
 hkl_output.close()
 
-print 'All done!'
+print('All done!')
 
         
 

--- a/SingleCrystal/latcon.py
+++ b/SingleCrystal/latcon.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 # 6 = Hexagonal
 # 7 = Cubic
 
-if sys.version_info > (3,0):
+if sys.version_info > (3,):
     from tkinter import *
     import tkinter.simpledialog as tkSimpleDialog
 else:

--- a/SingleCrystal/latcon.py
+++ b/SingleCrystal/latcon.py
@@ -1,6 +1,7 @@
 # latcon.py
 # Program to refine just the unit cell lattice constants but not the 
 # orientation matrix.
+from __future__ import print_function
 
 # A. Schultz
 # January 2015
@@ -14,8 +15,12 @@
 # 6 = Hexagonal
 # 7 = Cubic
 
-from Tkinter import *
-import tkSimpleDialog
+if sys.version_info > (3,0):
+    from tkinter import *
+    import tkinter.simpledialog as tkSimpleDialog
+else:
+    from Tkinter import *
+    import tkSimpleDialog
 
 import sys
 import numpy
@@ -205,7 +210,7 @@ while True:
     k_array.append(k)
     dsp_obs.append(dsp)
 
-print '\nNumber of peaks =', len(h_array)
+print('\nNumber of peaks =', len(h_array))
 output.write( '\nNumber of peaks = %d\n' % len(h_array) )
     
 h_array = numpy.array(h_array)
@@ -292,8 +297,8 @@ if crystal_system == '1':           # triclinic
     gamma = popt[5]
     V = volume_triclinic(a, b, c, alpha, beta, gamma)
     
-    print '\nLattice constants:'
-    print 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V)
+    print('\nLattice constants:')
+    print(7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V))
 
     alpha1 = alpha - 0.5*error[3]
     Va1 = volume_triclinic(a, b, c, alpha1, beta, gamma)
@@ -318,12 +323,12 @@ if crystal_system == '1':           # triclinic
             + (delta_V_beta/V)**2
             + (delta_V_gamma/V)**2            
             )**0.5
-    print 7*'  %10.6f' % (error[0], error[1], error[2], error[3], 
-        error[4], error[5], sigV)
+    print(7*'  %10.6f' % (error[0], error[1], error[2], error[3], 
+        error[4], error[5], sigV))
         
-    print '\nLattice constants:'
-    print 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V)
-    print 7*'  %10.6f' % (error[0], error[1], error[2], error[3], error[4], error[5], sigV)
+    print('\nLattice constants:')
+    print(7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V))
+    print(7*'  %10.6f' % (error[0], error[1], error[2], error[3], error[4], error[5], sigV))
     output.write( '\nLattice constants:\n' )
     output.write( 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V) )
     output.write( '\n' )
@@ -380,9 +385,9 @@ if crystal_system == '2':           # monoclinic
     delta_V = a*b*c*( numpy.sin(sin2) - numpy.sin(sin1))
     sigV = V * ( (error[0]/a)**2 + (error[1]/b)**2 + (error[2]/c)**2 
         + (delta_V / V)**2 )**0.5
-    print '\nLattice constants:'
-    print 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V)
-    print 7*'  %10.6f' % (error[0], error[1], error[2], zero, error[3], zero, sigV)
+    print('\nLattice constants:')
+    print(7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V))
+    print(7*'  %10.6f' % (error[0], error[1], error[2], zero, error[3], zero, sigV))
     output.write( '\nLattice constants:\n' )
     output.write( 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V) )
     output.write( '\n' )
@@ -420,9 +425,9 @@ if crystal_system == '3':           # orthorhombic
     V = a*b*c
     sigV = V * ( (error[0]/a)**2 + (error[1]/b)**2 + (error[2]/c)**2 )**0.5
     zero = 0.0
-    print '\nLattice constants:'
-    print 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V)
-    print 7*'  %10.6f' % (error[0], error[1], error[2], zero, zero, zero, sigV)
+    print('\nLattice constants:')
+    print(7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V))
+    print(7*'  %10.6f' % (error[0], error[1], error[2], zero, zero, zero, sigV))
     output.write( '\nLattice constants:\n' )
     output.write( 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V) )
     output.write( '\n' )
@@ -461,9 +466,9 @@ if crystal_system == '4':           # tetragonal
     V = a*b*c
     sigV = V * ( 2.0*(error[0]/a)**2 + (error[1]/c)**2 )**0.5
     zero = 0.0
-    print '\nLattice constants:'
-    print 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V)
-    print 7*'  %10.6f' % (error[0], zero, error[1], zero, zero, zero, sigV)
+    print('\nLattice constants:')
+    print(7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V))
+    print(7*'  %10.6f' % (error[0], zero, error[1], zero, zero, zero, sigV))
     output.write( '\nLattice constants:\n' )
     output.write( 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V) )
     output.write( '\n' )
@@ -507,9 +512,9 @@ if crystal_system == '5':           # rhombohedral
     # This is not correct. Needs work.
     sigV = V * ( 3.0*(error[0]/a)**2 + 5.0*(error[1]/alpha)**2 )**0.5
     zero = 0.0
-    print '\nLattice constants:'
-    print 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V)
-    print 7*'  %10.6f' % (error[0], zero, error[1], zero, zero, zero, sigV)
+    print('\nLattice constants:')
+    print(7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V))
+    print(7*'  %10.6f' % (error[0], zero, error[1], zero, zero, zero, sigV))
     
 #-----------------------------------------------        
 if crystal_system == '6':           # hexagonal
@@ -544,9 +549,9 @@ if crystal_system == '6':           # hexagonal
     V = numpy.sqrt(3.0) * a**2 * c / 2.0
     sigV = V * ( 2.0*(error[0]/a)**2 + (error[1]/c)**2 )**0.5
     zero = 0.0
-    print '\nLattice constants:'
-    print 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V)
-    print 7*'  %10.6f' % (error[0], zero, error[1], zero, zero, zero, sigV)
+    print('\nLattice constants:')
+    print(7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V))
+    print(7*'  %10.6f' % (error[0], zero, error[1], zero, zero, zero, sigV))
     output.write( '\nLattice constants:\n' )
     output.write( 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V) )
     output.write( '\n' )
@@ -581,9 +586,9 @@ if crystal_system == '7':           # cubic
     V = a*b*c
     sigV = V * ( 3.0*(error[0]/a)**2 )**0.5
     zero = 0.0
-    print '\nLattice constants:'
-    print 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V)
-    print 7*'  %10.6f' % (error[0], zero, zero, zero, zero, zero, sigV)
+    print('\nLattice constants:')
+    print(7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V))
+    print(7*'  %10.6f' % (error[0], zero, zero, zero, zero, zero, sigV))
     output.write( '\nLattice constants:\n' )
     output.write( 7*'  %10.6f' % (a,b,c,alpha,beta,gamma,V) )
     output.write( '\n' )
@@ -593,8 +598,8 @@ if crystal_system == '7':           # cubic
 
 output.write( '\n' )
 
-print '\nResults saved to latcon.out file.'
-print '\nAll done!'    
+print('\nResults saved to latcon.out file.')
+print('\nAll done!')    
 
     
     

--- a/SingleCrystal/lin_abs_coef2.py
+++ b/SingleCrystal/lin_abs_coef2.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 # Version 2:
 # A.J. Schultz, August 2015
 
-if sys.version_info > (3,0):
+if sys.version_info > (3,):
     from tkinter import *
     import tkinter.simpledialog as tkSimpleDialog
 else:

--- a/SingleCrystal/lin_abs_coef2.py
+++ b/SingleCrystal/lin_abs_coef2.py
@@ -1,6 +1,7 @@
 #-----------------------------------
 #           lin_abs_coef v2.py
 #-----------------------------------
+from __future__ import print_function
 
 # Program to calculate linear absorption coefficients and density.
 # Version 1 requires ISAW. Version 2 is a stand alone script.
@@ -8,8 +9,12 @@
 # Version 2:
 # A.J. Schultz, August 2015
 
-from Tkinter import *
-import tkSimpleDialog
+if sys.version_info > (3,0):
+    from tkinter import *
+    import tkinter.simpledialog as tkSimpleDialog
+else:
+    from Tkinter import *
+    import tkSimpleDialog
 
 import math
 
@@ -94,8 +99,8 @@ logFile.write('\nCross sections in units of barns ( 1 barn = 1E-24 cm^2)\n')
 logFile.write('Absorption cross section for 2200 m/s neutrons (wavelength = 1.8 A)\n')
 logFile.write('For further information and references, see ...\ISAW\Databases\NIST_cross-sections.dat\n')
 
-print '\nAtom      ScatXs      AbsXs'	# print headings
-print   '----      ------      -----'
+print('\nAtom      ScatXs      AbsXs')	# print headings
+print('----      ------      -----')
 logFile.write('\nAtom      ScatXs      AbsXs\n')
 logFile.write(  '----      ------      -----\n')
 
@@ -138,7 +143,7 @@ for i in range(numberOfIsotopes):
     atomicWeight = float(lineList[4])   # atomic weight
     number = float(formulaList[i][lenSymbol:])   # the number of this nuclei in the formula
     
-    print '%-5s %10.5f %10.5f' % (lineList[0], scatteringXs, absorptionXs)
+    print('%-5s %10.5f %10.5f' % (lineList[0], scatteringXs, absorptionXs))
     logFile.write('%-5s %10.5f %10.5f\n' % (lineList[0], scatteringXs, absorptionXs))
     
     sumScatXs = sumScatXs + ( number * scatteringXs )
@@ -156,10 +161,10 @@ muAbs = sumAbsXs * zParameter / unitCellVolume
 density = (sumAtWt / 0.6022) * zParameter / unitCellVolume
 
 # Print the results.
-print '\n'
-print 'The linear absorption coefficent for total scattering is %6.3f cm^-1' % muScat
-print 'The linear absorption coefficent for true absorption at 1.8 A is %6.3f cm^-1' % muAbs
-print 'The calculated density is %6.3f grams/cm^3' % density
+print('\n')
+print('The linear absorption coefficent for total scattering is %6.3f cm^-1' % muScat)
+print('The linear absorption coefficent for true absorption at 1.8 A is %6.3f cm^-1' % muAbs)
+print('The calculated density is %6.3f grams/cm^3' % density)
 logFile.write('\n')
 logFile.write('The linear absorption coefficent for total scattering is %6.3f cm^-1\n' % muScat)
 logFile.write('The linear absorption coefficent for true absorption at 1.8 A is %6.3f cm^-1\n' % muAbs)
@@ -168,14 +173,14 @@ logFile.write('\nThe calculated density is %6.3f grams/cm^3\n' % density)
 # if calcRadius:
 if weight != 0.0:
     crystalVolume = weight / (density)   # sample volume in mm^3
-    print 'For a weight of %6.3f mg, the crystal volume is %6.3f mm^3' % (weight, crystalVolume)
+    print('For a weight of %6.3f mg, the crystal volume is %6.3f mm^3' % (weight, crystalVolume))
     logFile.write('\nFor a weight of %6.3f mg, the crystal volume is %6.3f mm^3\n' % (weight, crystalVolume))
     crystalRadius = ( crystalVolume / ((4.0/3.0)*math.pi) )**(1.0/3.0)   # radius in mm
-    print 'The crystal radius is %6.3f mm, or %6.4f cm' % (crystalRadius, crystalRadius/10.)
+    print('The crystal radius is %6.3f mm, or %6.4f cm' % (crystalRadius, crystalRadius/10.))
     logFile.write('The crystal radius is %6.3f mm, or %6.4f cm\n' % (crystalRadius, crystalRadius/10.))
     # volCalc = (4.0/3.0) * math.pi * crystalRadius**3
     # print 'volCalc = %6.3f' % volCalc
 
 logFile.close()
-print 'All done!'
+print('All done!')
 

--- a/direct_inelastic/LET/PLET_quartz.py
+++ b/direct_inelastic/LET/PLET_quartz.py
@@ -1,4 +1,9 @@
 import PolCorr
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload(PolCorr)
 from mantid import *
 
@@ -12,7 +17,7 @@ from mantid import *
 # The calculated Polarizer/Flipper efficency PF should be used for 
 # the data reduction in PLET_reduction_sample.py
 
-sample_runs=range(57810,57820)
+sample_runs=list(range(57810,57820))
 eis = [6.13,3.20,1.96] 
 pressure = 0.9
 

--- a/direct_inelastic/LET/PLET_reduction_template.py
+++ b/direct_inelastic/LET/PLET_reduction_template.py
@@ -1,4 +1,9 @@
 import PolCorr
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload(PolCorr)
 from mantid import *
 
@@ -17,7 +22,7 @@ PF = [0.95 - x*0.047 for x in eis]  # Polarizer/Flipper efficency for each ei.
 #   polmon_delay    - defualt 100 microsec
 #   mask            - default 'PLET_184_msk.xml'
 
-sample_runs=range(58310,58350); lbl='PEO-D_375K'  # LET12
+sample_runs=list(range(58310,58350)); lbl='PEO-D_375K'  # LET12
 
 data = PolCorr.Reduce(sample_runs,eis,PF,he_pressure=pressure,NSF_first=NSF_first,label=lbl)
 

--- a/direct_inelastic/MAPS/template_maps.py
+++ b/direct_inelastic/MAPS/template_maps.py
@@ -1,16 +1,22 @@
+from __future__ import print_function
 from mantid import config
 from MAPSReduction_Sample import *
 import time
 import os
 import datetime
 import sys
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 try:
     #Note: due to the mantid-python implementation, one needs to run this 
     #script in Mantid  script window  TWICE!!!  to deploy  the the changes made to MAPSReduction_Sample.py file.
     sys.path.insert(0,'/instrument/MAPS/RBNumber/USER_RB_FOLDER');    #<- template parameter, modified on isiscompute to correct user
     reload(sys.modules['MAPSReduction_Sample'])
 except:
-    print "*** WARNING can not reload MAPSReduction_Sample file"
+    print("*** WARNING can not reload MAPSReduction_Sample file")
     pass
 
 config['defaultsave.directory'] = '/instrument/MAPS/RBNumber/USER_RB_FOLDER' #data_dir 

--- a/direct_inelastic/MARI/template_mari.py
+++ b/direct_inelastic/MARI/template_mari.py
@@ -1,16 +1,22 @@
+from __future__ import print_function
 from mantid import config
 from MARIReduction_Sample import *
 import time
 import os
 import datetime
 import sys
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 try:
     #Note: due to the mantid-python implementation, one needs to run this 
     #script in Mantid  script window  TWICE!!!  to deploy the the changes made to MARIReduction_Sample.py file.
     sys.path.insert(0,'/instrument/MARI/RBNumber/USER_RB_FOLDER/')
     reload(sys.modules['MARIReduction_Sample'])
 except:
-    print "*** WARNING can not reload MARIReduction_Sample file"
+    print("*** WARNING can not reload MARIReduction_Sample file")
     pass
 
 # Run number and Ei

--- a/direct_inelastic/MARI/template_mari_dos.py
+++ b/direct_inelastic/MARI/template_mari_dos.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid import config
 from MARIReduction_Sample import *
 import time
@@ -5,13 +6,18 @@ import os
 import datetime
 import sys
 import numpy as np
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 try:
     #Note: due to the mantid-python implementation, one needs to run this 
     #script in Mantid  script window  TWICE!!!  to deploy the the changes made to MARIReduction_2018_4.py file.
     sys.path.insert(0,'/instrument/MARI/RBNumber/USER_RB_FOLDER/')
     reload(sys.modules['MARIReduction_Sample'])
 except:
-    print "*** WARNING can not reload MARIReduction_Sample file"
+    print("*** WARNING can not reload MARIReduction_Sample file")
     pass
     
 # START EDITING HERE
@@ -38,11 +44,11 @@ load_reduce = True
 # ssf is the self-shielding factor and msd is the mean-square displacement per sample and temperature
 runs = {        
     'Sample_1': {'sam_mass':0, 'sam_rmm':0,
-                           5: {'data': range(25478,25485), 'background': range(25492,25500), 'recalc':True, 'ssf':1., 'msd':0.}, 
+                           5: {'data': list(range(25478,25485)), 'background': list(range(25492,25500)), 'recalc':True, 'ssf':1., 'msd':0.}, 
                      },
     'Sample_2': {'sam_mass':0, 'sam_rmm':0,
-                           5: {'data': range(25506,25516), 'background': range(25492,25500), 'recalc':True, 'ssf':1., 'msd':0.}, 
-                           300: {'data': range(25526,25536), 'background': range(25501,25510), 'recalc':True, 'ssf':1., 'msd':0.}, 
+                           5: {'data': list(range(25506,25516)), 'background': list(range(25492,25500)), 'recalc':True, 'ssf':1., 'msd':0.}, 
+                           300: {'data': list(range(25526,25536)), 'background': list(range(25501,25510)), 'recalc':True, 'ssf':1., 'msd':0.}, 
                      },
 }
 

--- a/direct_inelastic/MERLIN/iliad_merlin.py
+++ b/direct_inelastic/MERLIN/iliad_merlin.py
@@ -1,6 +1,11 @@
 import  MERReductionSrRuO3 as mpr
 from mantid.simpleapi import *
 from mantid import config
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 
 reload(mpr)
 rd=mpr.MERLINReduction()

--- a/indirect_inelastic/models/QENS_lib/QENS_lib_install.py
+++ b/indirect_inelastic/models/QENS_lib/QENS_lib_install.py
@@ -1,4 +1,5 @@
 #run this in Mantid scripting window
+from __future__ import print_function
 import subprocess
 
 """
@@ -6,8 +7,8 @@ You will need to download/checkout the QENS library: https://github.com/QENSlibr
 The path below needs to be the full path to where you have saved the above.
 Run this script and the QENSmodels should be available as part of Mantid
 """
-path_to_QENS_lib = "C:\Users\BTR75544\work\QENSlib\QENSmodels"
+path_to_QENS_lib = "C:\\Users\BTR75544\work\QENSlib\QENSmodels"
 
 # install phase
-print(subprocess.Popen("python -m pip install -U --no-deps "+path_to_QENS_lib ,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate())
+print((subprocess.Popen("python -m pip install -U --no-deps "+path_to_QENS_lib ,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
 

--- a/indirect_inelastic/models/QENS_lib/QENS_lib_install.py
+++ b/indirect_inelastic/models/QENS_lib/QENS_lib_install.py
@@ -10,5 +10,5 @@ Run this script and the QENSmodels should be available as part of Mantid
 path_to_QENS_lib = "C:\\Users\BTR75544\work\QENSlib\QENSmodels"
 
 # install phase
-print((subprocess.Popen("python -m pip install -U --no-deps "+path_to_QENS_lib ,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate()))
+print(subprocess.Popen("python -m pip install -U --no-deps "+path_to_QENS_lib ,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE).communicate())
 

--- a/indirect_inelastic/models/StretchedExpFT/v3.8.0/algFitStretchedExpFT.py
+++ b/indirect_inelastic/models/StretchedExpFT/v3.8.0/algFitStretchedExpFT.py
@@ -5,22 +5,24 @@
   - email to <mantid-help@mantidproject.org>
 '''
 from __future__ import print_function
+
 import string
 import os
 import sys
 import re
 import numpy as np
 from collections import OrderedDict
-if sys.version.split('.')[:2] < list(('3', '4')):
-    from imp import reload
-else:
-    from importlib import reload
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 
 import mantid.api as mapi
 import mantid.simpleapi as msapi
 import mantid.kernel as mkrnl
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-import seqFitStretchedExFT
+import seqFitStretchedExFT # don't need from . as have __init__.py in dir
 
 
 reload(seqFitStretchedExFT)
@@ -148,7 +150,7 @@ name=LinearBackground,A0=${f1_A0},A1=${f1_A1}
         # Find out selected workspaces and sort from lowest to highest
         selectedwi = self.getProperty("SelectedWI").value
         if not selectedwi.any():
-            selectedwi = np.array(range(mapi.mtd[self.getPropertyValue("DataWorkspace")].getNumberHistograms()))
+            selectedwi = np.array(list(range(mapi.mtd[self.getPropertyValue("DataWorkspace")].getNumberHistograms())))
         selectedwi.sort()
         selectedwi = selectedwi[::-1] # from Highest to lowest
         self.setProperty("SelectedWI", selectedwi)
@@ -206,7 +208,7 @@ name=LinearBackground,A0=${f1_A0},A1=${f1_A1}
         """
         template = string.Template(self._fitTpl)
         # Find initial guess values
-        kwargs = {key:str(self.getProperty(prop).value) for prop,key in self._propvalue2key.items()}
+        kwargs = {key:str(self.getProperty(prop).value) for prop,key in list(self._propvalue2key.items())}
         if wi >= 0:
             kwargs.update({"wi":str(wi)})
         return template.safe_substitute(**kwargs)  # this self._fitTpl is owned by object, not class
@@ -228,7 +230,7 @@ name=LinearBackground,A0=${f1_A0},A1=${f1_A1}
         # Iterate over the table contents
         for row in parmtable:
             name = row['Name'].replace('.', '_')  # name of the fitting parameter
-            for propvalue, key in self._propvalue2key.items():
+            for propvalue, key in list(self._propvalue2key.items()):
                 if name == key:
                     factor = 1.0
                     if name == "f0_f1_f1_Tau":

--- a/indirect_inelastic/models/StretchedExpFT/v3.8/algorithm_version/algFitStretchedExpFT.py
+++ b/indirect_inelastic/models/StretchedExpFT/v3.8/algorithm_version/algFitStretchedExpFT.py
@@ -4,6 +4,7 @@
   - message in the "Contact us" page <http://www.mantidproject.org/Contact>
   - email to <mantid-help@mantidproject.org>
 '''
+from __future__ import print_function
 
 import mantid.api as mapi
 import mantid.simpleapi as msapi
@@ -14,6 +15,11 @@ import sys
 import re
 import numpy as np
 from collections import OrderedDict
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 import seqFitStretchedExFT
 reload(seqFitStretchedExFT)
@@ -138,7 +144,7 @@ name=LinearBackground,A0=${f1_A0},A1=${f1_A1}
         # Find out selected workspaces and sort from lowest to highest
         selectedwi = self.getProperty("SelectedWI").value
         if not selectedwi.any():
-            selectedwi = np.array(range(mapi.mtd[self.getPropertyValue("DataWorkspace")].getNumberHistograms()))
+            selectedwi = np.array(list(range(mapi.mtd[self.getPropertyValue("DataWorkspace")].getNumberHistograms())))
         selectedwi.sort()
         selectedwi = selectedwi[::-1] # from Highest to lowest
         self.setProperty("SelectedWI", selectedwi)
@@ -149,8 +155,8 @@ name=LinearBackground,A0=${f1_A0},A1=${f1_A1}
         else:
             fit_scheme_mod = FitStretchedExpFT._scheme2mod[self.getProperty("FitScheme").value]  # seq or glob module
 
-            print dir(fit_scheme_mod)
-            print os.path.abspath(fit_scheme_mod.__file__)
+            print(dir(fit_scheme_mod))
+            print(os.path.abspath(fit_scheme_mod.__file__))
             fitter = fit_scheme_mod.FitWorker(self)  # call sequential or global fit
             fitter.doFit()
             fitter.dependQ()  # create workspaces with Q-dependence
@@ -196,7 +202,7 @@ name=LinearBackground,A0=${f1_A0},A1=${f1_A1}
         """
         template = string.Template(self._fitTpl)
         # Find initial guess values
-        kwargs = {key:str(self.getProperty(prop).value) for prop,key in self._propvalue2key.items()}
+        kwargs = {key:str(self.getProperty(prop).value) for prop,key in list(self._propvalue2key.items())}
         if wi >= 0:
             kwargs.update({"wi":str(wi)})
         return template.safe_substitute(**kwargs)  # this self._fitTpl is owned by object, not class
@@ -218,7 +224,7 @@ name=LinearBackground,A0=${f1_A0},A1=${f1_A1}
         # Iterate over the table contents
         for row in parmtable:
             name = row['Name'].replace('.', '_')  # name of the fitting parameter
-            for propvalue, key in self._propvalue2key.items():
+            for propvalue, key in list(self._propvalue2key.items()):
                 if name == key:
                     factor = 1.0
                     if name == "f0_f1_f1_Tau":

--- a/indirect_inelastic/models/StretchedExpFTTauQ/v3.8/gloFitStretchedExFTTauQ.py
+++ b/indirect_inelastic/models/StretchedExpFTTauQ/v3.8/gloFitStretchedExFTTauQ.py
@@ -15,6 +15,7 @@
   Parameters Beta, TauMax, and Alpha of fit function StretchedExFTTauQ are the same for all spectra.
   All other fitting parameters are different for each spectrum.
 '''
+from __future__ import print_function
 
 import re
 from copy import copy
@@ -105,19 +106,19 @@ seqOutput = sequentialFit(resolution, data, fitstring_template, initguess, [minE
 individuals = {"Beta": list(), "TauMax": list(), "Alpha": list()}
 # collect the individual values at each spectrum
 for i in range(len(seqOutput["funcStrings"])):
-    for name in individuals.keys():
+    for name in list(individuals.keys()):
         match = re.search("{0}=(\d+\.\d+)".format(name), seqOutput["funcStrings"][i])
         individuals[name].append(float(match.groups()[0]))
 # calculate the averages
 averages = dict()
-for name in individuals.keys():
+for name in list(individuals.keys()):
     averages[name] = "{0}={1}".format(name, str(sum(individuals[name])/len(individuals[name])))
 # substitute the individual values with the averages
 for i in range(len(seqOutput["funcStrings"])):
-    for name in individuals.keys():
+    for name in list(individuals.keys()):
         seqOutput["funcStrings"][i] = re.sub("{0}=\d+\.\d+".format(name),averages[name],
                                              seqOutput["funcStrings"][i])
-print seqOutput["funcStrings"]
+print(seqOutput["funcStrings"])
 
 # Merge models for each spectra
 global_model= 'composite=MultiDomainFunction,NumDeriv=true;'
@@ -126,12 +127,12 @@ for funcString in seqOutput["funcStrings"]:
 
 # Insert the ties for Beta, TauMax, and Alpha parameters
 ties = {"Beta": "", "TauMax": "", "Alpha": ""}
-for name in ties.keys():
-    for i in reversed(range(len(selected_wi))):  
+for name in list(ties.keys()):
+    for i in reversed(list(range(len(selected_wi)))):  
         ties[name] += "f{0}.f0.f1.f1.{1}=".format(i, name)
-all_ties = "ties=(" + ','.join([ties[name].strip("=") for name in ties.keys()]) + ')'
+all_ties = "ties=(" + ','.join([ties[name].strip("=") for name in list(ties.keys())]) + ')'
 global_model += all_ties
-print global_model
+print(global_model)
 #Relate spectra to domains
 spectra_domain_relation = dict()
 domain_index = 0
@@ -154,10 +155,10 @@ parameters_workspace = mtd[output_workspace+"_Parameters"]
 shorties = {"f0.f1.f0.Height": "EISF", "f0.f1.f1.TauMax": "taumax",
             "f0.f1.f1.Alpha": "alpha", "f0.f1.f1.Beta": "beta", }
 other = dict()
-for shorty in shorties.values():
+for shorty in list(shorties.values()):
     other[shorty] = list()
 other["qvalues"] = [qvalues[iq] for iq in selected_wi]
-names = shorties.keys()
+names = list(shorties.keys())
 for row in parameters_workspace:
     # name of the fitting parameter for this particular row
     matches = re.search("^f(\d+)\.(.*)", row['Name']) # for instance, f0.f0.f1.f0.Height
@@ -167,7 +168,7 @@ for row in parameters_workspace:
             other[shorties[name]].append(row["Value"])
 # calculate tau
 other["tau"] = (other['taumax'][0]*(qmin/np.array(other["qvalues"]))**other["alpha"][0]).tolist()
-print other
+print(other)
 # Save Q-dependencies of the optimized parameters, and also tau
 nspectra = 5
 dataY = other["EISF"] + other['taumax'] + other['alpha'] + other['tau'] + other['beta']

--- a/muon/MaxEnt/Tests/TestMaxEnt.py
+++ b/muon/MaxEnt/Tests/TestMaxEnt.py
@@ -26,7 +26,7 @@ class TestMaxEntMUSR(unittest.TestCase):
         actual_ws = mtd[actual_ws_name]
         expected_ws = LoadNexus(os.path.join(SCRIPT_DIR, expected_file_name))
         result = CheckWorkspacesMatch(Workspace1=actual_ws, Workspace2=expected_ws)
-        self.assertEquals(result, "Success!", "\"%s\"" % result)
+        self.assertEqual(result, "Success!", "\"%s\"" % result)
 
     def test_fit_and_fix_checked(self):
         self.max_ent_alg.setProperty("FitDeadTimes", True)

--- a/reflectometry/ISISPythonControl/PolrefControl/PolrefRoutines.py
+++ b/reflectometry/ISISPythonControl/PolrefControl/PolrefRoutines.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from genie_python.genie import *
 import numpy as np
 import matplotlib.pyplot as plt
-
+from six import moves
 import sys,os
 
 def groupname(name=''):  # Currently Broken. Unsure Why.
@@ -14,11 +14,11 @@ def groupname(name=''):  # Currently Broken. Unsure Why.
     '''
     if name=='':
         # Ask for a name
-        name=eval(input('What is your group name? '))
+        name=moves.input('What is your group name? ')
     if os.path.isdir('u:/%s'%name):
         os.chdir('u:/%s'%name)
     else:
-        answer=eval(input(r'Group directory %s not found in u:\. Make a new one? '%name))
+        answer=moves.input(r'Group directory %s not found in u:\. Make a new one? '%name)
         if answer == 'y' or answer == 'Y':
             print('u:/%s'%name)
             #os.mkdir('u:/%s'%name)            
@@ -150,7 +150,7 @@ def ascan(*args, **kwargs):
         abort()
     change(nperiods=Npts)
     begin(paused=True)
-    print(('#%s\t\tI/Io\t\tErr\t\tI\t\tIo'%BlockName))
+    print('#%s\t\tI/Io\t\tErr\t\tI\t\tIo'%BlockName)
     for i,x in enumerate(x_values):
         #cset(stheta=x)
         exec('cset(%s=x)'%BlockName)
@@ -170,7 +170,7 @@ def ascan(*args, **kwargs):
         else:
             y_values[i]=0.0
             e_values[i]=0.0
-        print(('%10.3f\t%10.3g\t%10.3g\t%10.3g\t%10.3g'%(x_values[i], y_values[i], e_values[i], CountsInI, CountsInIo)))
+        print('%10.3f\t%10.3g\t%10.3g\t%10.3g\t%10.3g'%(x_values[i], y_values[i], e_values[i], CountsInI, CountsInIo))
         # update the plot with the data
         line.set_ydata(y_values)
         bottoms.set_ydata(y_values - 0.5*e_values)

--- a/reflectometry/ISISPythonControl/PolrefControl/PolrefRoutines.py
+++ b/reflectometry/ISISPythonControl/PolrefControl/PolrefRoutines.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from genie_python.genie import *
 import numpy as np
 import matplotlib.pyplot as plt
@@ -13,13 +14,13 @@ def groupname(name=''):  # Currently Broken. Unsure Why.
     '''
     if name=='':
         # Ask for a name
-        name=input('What is your group name? ')
+        name=eval(input('What is your group name? '))
     if os.path.isdir('u:/%s'%name):
         os.chdir('u:/%s'%name)
     else:
-        answer=input(r'Group directory %s not found in u:\. Make a new one? '%name)
+        answer=eval(input(r'Group directory %s not found in u:\. Make a new one? '%name))
         if answer == 'y' or answer == 'Y':
-            print 'u:/%s'%name
+            print('u:/%s'%name)
             #os.mkdir('u:/%s'%name)            
 
 def waitformove():
@@ -59,13 +60,13 @@ def pol_run(u=5000, d=5000, total=0, Title='', SampleName=''):
             if i == 0 :
                 change(period=1)
                 flipper('up')
-                print 'counting on spin up for %d frames'%polstate[i], 'Framecount / Total ', framecount,'/ ', total
+                print('counting on spin up for %d frames'%polstate[i], 'Framecount / Total ', framecount,'/ ', total)
             if i == 1 :
                 change(period=2)
                 flipper('dn')
-                print 'counting on spin dn for %d frames'%polstate[i], 'Framecount / Total ', framecount,'/ ', total
+                print('counting on spin dn for %d frames'%polstate[i], 'Framecount / Total ', framecount,'/ ', total)
         
-            print "A small pause to stop cross contamination of polarisation states:"
+            print("A small pause to stop cross contamination of polarisation states:")
             waitfor(seconds=3)  # CJK 11/10/2013 wait to stop cross contamination of pol states
             resume()
             waitfor(frames=(polstate[i] + framecount))
@@ -106,11 +107,11 @@ def ascan(*args, **kwargs):
     elif nargs==8:
         BlockName, Start, Stop, Npts, Frames, Io, I, Save = args
     elif nargs >8:
-        print 'Too many arguments'
+        print('Too many arguments')
         return
                
     # Unpack any keyword arguments
-    for k,v in kwargs.iteritems():
+    for k,v in kwargs.items():
         if k == 'Block':
             BlockName=v
         elif k == 'Start':
@@ -128,7 +129,7 @@ def ascan(*args, **kwargs):
         elif k == 'Save':
             Save=v
                 
-    print '#', BlockName, Start, Stop, Npts, Frames, Io, I, Save
+    print('#', BlockName, Start, Stop, Npts, Frames, Io, I, Save)
     
     # build array of axis values
     x_values = np.linspace(Start, Stop, Npts)
@@ -143,13 +144,13 @@ def ascan(*args, **kwargs):
 
     CurrentState=get_runstate()
     if CurrentState[0] !=1 : # Here 1 = Setup
-        print 'Cant start a scan if instrument is "Running".'
-        print ' Will abort current run in 30 sec. Use ctrl-c to stop action.'
+        print('Cant start a scan if instrument is "Running".')
+        print(' Will abort current run in 30 sec. Use ctrl-c to stop action.')
         waitfor(seconds=30)
         abort()
     change(nperiods=Npts)
     begin(paused=True)
-    print('#%s\t\tI/Io\t\tErr\t\tI\t\tIo'%BlockName)
+    print(('#%s\t\tI/Io\t\tErr\t\tI\t\tIo'%BlockName))
     for i,x in enumerate(x_values):
         #cset(stheta=x)
         exec('cset(%s=x)'%BlockName)
@@ -169,7 +170,7 @@ def ascan(*args, **kwargs):
         else:
             y_values[i]=0.0
             e_values[i]=0.0
-        print('%10.3f\t%10.3g\t%10.3g\t%10.3g\t%10.3g'%(x_values[i], y_values[i], e_values[i], CountsInI, CountsInIo))
+        print(('%10.3f\t%10.3g\t%10.3g\t%10.3g\t%10.3g'%(x_values[i], y_values[i], e_values[i], CountsInI, CountsInIo)))
         # update the plot with the data
         line.set_ydata(y_values)
         bottoms.set_ydata(y_values - 0.5*e_values)
@@ -229,15 +230,15 @@ def pump(A=25, B=25, C=25, D=25,Flow=5, Wait=180):
     '''pump(A=25, B=25, C=25, D=25,Flow=5, Wait=180):
     '''
     if A+B+C+D != 100:
-        print "Pump: Please make your channel values add up to 100"
+        print("Pump: Please make your channel values add up to 100")
         return
     if Wait == 180:
-        print "Pump: Using default wait of 180 s"
+        print("Pump: Using default wait of 180 s")
 
     cset(concA=A, concB=B, concC=C, concD=D, hplcflow=Flow)
     waitfor(seconds=2)
     cset(hplcset=1)
     cset(pump_on_off=1)# turn the pump on
-    print "Waiting for "+str(wait)+"s"
+    print("Waiting for "+str(wait)+"s")
     waitfor(seconds=Wait)
     cset(pump_on_off=0)     # turn the pump off

--- a/reflectometry/offspec/event_scripts.py
+++ b/reflectometry/offspec/event_scripts.py
@@ -1,4 +1,10 @@
+from __future__ import print_function
 import offspec_offset2 as nr
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload(nr)
 nr.current_detector = nr.old_detector
 
@@ -11,7 +17,7 @@ def getLog(w,log_name):
         try:
           h=mtd[w]
         except:
-          print "Can't get Workspace handle"
+          print("Can't get Workspace handle")
         #
         # Get access to SampleDetails
 	s=h.getSampleDetails().getLogData(log_name).value
@@ -94,7 +100,7 @@ def loadlatest(currentrun=None):
                 endings.append(filelist[1])
             except: pass   
     sortedendings = sorted(endings)
-    print targetname+'.n'+sortedendings[-1]
+    print(targetname+'.n'+sortedendings[-1])
     return targetname+'.n'+sortedendings[-1]
 
 def loaddata(rnum, path = 'L://RawData/cycle_15_3/',loadcrpt=0):
@@ -106,7 +112,7 @@ def loaddata(rnum, path = 'L://RawData/cycle_15_3/',loadcrpt=0):
               updatefile=loadlatest(str(rnum))   
               Load(Filename='z:/'+updatefile, OutputWorkspace=str(rnum), LoaderName='LoadEventNexus', LoaderVersion=1, LoadMonitors=True)
             else:
-              print 'trying to load crpt snapshot'
+              print('trying to load crpt snapshot')
               Load(Filename='z:/snapshot_crpt.nxs', OutputWorkspace=str(rnum), LoaderName='LoadEventNexus', LoaderVersion=1, LoadMonitors=True)
         except: 
             raise Exception('Could not find data')
@@ -122,10 +128,10 @@ def timeslice(rnum,btime,etime,output,loadcrpt=0):
     a1=mtd[str(rnum)]
     gr=a1.getRun()
     tamps=gr.getProtonCharge()
-    print 'tamps=',str(tamps)
+    print('tamps=',str(tamps))
     a2=mtd[str(rnum)+'_slice']
     ua=a2.getRun().getProtonCharge()
-    print 'ua=',str(ua)
+    print('ua=',str(ua))
     monnorm=mtd[str(rnum)+'_monitors']*ua/tamps
     Rebin(monnorm,'5.0,20.0,100000.0',OutputWorkspace=str(rnum)+'monreb')
     ConjoinWorkspaces(str(rnum)+'monreb',str(rnum)+'_slicereb',CheckOverlapping=False)
@@ -256,7 +262,7 @@ def offspecslice2(rnum,qmin,qmax,output,start = 0, tslice=None,nslices = None,sa
     if tslice or nslices: # if tslice or nslices exist they will take precedence over slicearray
         testws = loaddata(rnum,loadcrpt=loadcrpt)
         runtotaltime = getLog(testws, 'duration')
-        print "Total runtime in seconds: " + str(runtotaltime)
+        print("Total runtime in seconds: " + str(runtotaltime))
         DeleteWorkspace(testws)
         if nslices: 
             tslice = ceil((runtotaltime - start)/(nslices))
@@ -264,22 +270,25 @@ def offspecslice2(rnum,qmin,qmax,output,start = 0, tslice=None,nslices = None,sa
         while slicearray[-1] < runtotaltime:
             slicearray.append(slicearray[-1]+tslice)
         slicearray[-1] = runtotaltime # lastentry is some random number > than total runduration, set equal to runduration, this means the last slice has a different length to the others
-        print "Time boundaries:\n" 
-        print slicearray
-        print "Start making slices:\n"
+        print("Time boundaries:\n") 
+        print(slicearray)
+        print("Start making slices:\n")
     for idx in range(len(slicearray)):
         try:
             start = slicearray[idx]; end = slicearray[idx+1]
             datatimes.append(0.5*(start+end)) # calculate the time for this dataset for saving later
-            print "\nCreated slice "+str(datatimes[-1])
+            print("\nCreated slice "+str(datatimes[-1]))
             _offspecslice_simple(rnum, start, end, qmin, qmax, output, binning=binning, theta=theta,spec=spec,loadcrpt=loadcrpt)
         except:
-            print datatimes
+            print(datatimes)
             break
        
 
-def offspecPlot(wksp, (xmin, xmax), (ymin,ymax), (zmin,zmax),logscale='z'):
+def offspecPlot(wksp, xrange, yrange, zrange,logscale='z'):
     
+    (xmin, xmax) = xrange
+    (ymin,ymax) = yrange
+    (zmin,zmax) = zrange
     p = plot2D(wksp)
     l=p.activeLayer()
     l.setScale(0, ymin, ymax)
@@ -319,10 +328,10 @@ def offspecQplot(rnum,qmin,qmax,output, nslices=None,sarray = [], angle=0.7,Nqx=
         if m:
             n = re.search('^wrong{1}(.*)detnorm{1}$', name)
             if n:
-                print name
+                print(name)
                 newname = re.sub('wrong',output, name)
                 newname = re.sub('detnorm','',newname)
-                print "newname: "+newname
+                print("newname: "+newname)
                 ConvertSpectrumAxis(InputWorkspace=name, OutputWorkspace=name, Target='SignedTheta')
                 try:
                     ConvertToReflectometryQ(InputWorkspace=name, OverrideIncidentTheta=True, IncidentTheta=angle, Extents=qxqzlimits, OutputAsMDWorkspace=False, OutputWorkspace=newname+"qxqz", NumberBinsQx=Nqx, NumberBinsQz=Nqz)
@@ -343,7 +352,7 @@ def chopit(rnum,btime,etime,tslice,output,slicearray=None,usearray=0,sf=1.0, sav
     
     nslice=int((etime*1.0-btime)/(tslice*1.0))
     slicenames=[]
-    print 'nslice=',str(nslice)
+    print('nslice=',str(nslice))
     if usearray==0:
         slicearray=[]
         slicearray.append(btime)
@@ -358,9 +367,9 @@ def chopit(rnum,btime,etime,tslice,output,slicearray=None,usearray=0,sf=1.0, sav
         try:
             wksp=timeslice(rnum,btime2,etime2,output,loadcrpt=loadcrpt)
             slicenames.append(wksp)
-            print slicenames
+            print(slicenames)
         except:
-            print 'time slicing failed'
+            print('time slicing failed')
             break
         nr.nrNRFn("",wksp,"0.700","LDDB05k","114","110","120",binning,"",usewkspname=1,sf=sf)
         #Rebin(wksp+"RvQ","0.011,-0.025,0.09",OutputWorkspace=wksp+"RvQ")
@@ -377,7 +386,7 @@ def chopit(rnum,btime,etime,tslice,output,slicearray=None,usearray=0,sf=1.0, sav
         datatimes.append(0.5*(slicearray[i]+slicearray[i+1]))
     writemap_csv(output+'_allslices',datatimes,'C:/everything/userthings/'+output+'/'+output)
     if save:
-        print "\n Trying to save the following slices: \n"
+        print("\n Trying to save the following slices: \n")
         saveslices(output+'_allslices','C:/everything/userthings/'+output+'/')
 
 def saveslices(inputwksp, dir = None):
@@ -386,15 +395,15 @@ def saveslices(inputwksp, dir = None):
     else:
         userdirectory = "C:/everything/userthings/"
     spectrum = 0
-    print spectrum
+    print(spectrum)
     while True:
         try:
             filename = userdirectory + inputwksp + "_" + str(spectrum) + ".dat"
             SaveAscii(inputwksp, filename, SpectrumList = [spectrum], WriteSpectrumID = False, CommentIndicator = "#", Separator = "Tab", ColumnHeader = False)
             spectrum += 1
-            print spectrum
+            print(spectrum)
         except: 
-            print "End of slices reached, this one does not exist: " + str(spectrum)
+            print("End of slices reached, this one does not exist: " + str(spectrum))
             break
 
 
@@ -406,7 +415,7 @@ def chopit2(rnum,output,start = 0, tslice=None,nslices = None ,sarray=[],usearra
     if tslice or nslices: # if tslice or nslices exist they will take precedence over slicearray
         testws = loaddata(rnum,loadcrpt=loadcrpt)
         runtotaltime = getLog(testws, 'duration')
-        print "Total runtime in seconds: " + str(runtotaltime)
+        print("Total runtime in seconds: " + str(runtotaltime))
         DeleteWorkspace(testws)
         if nslices: 
             tslice = ceil((runtotaltime - start)/(nslices))
@@ -414,9 +423,9 @@ def chopit2(rnum,output,start = 0, tslice=None,nslices = None ,sarray=[],usearra
         while slicearray[-1] < runtotaltime:
             slicearray.append(slicearray[-1]+tslice)
         slicearray[-1] = runtotaltime # lastentry is some random number > than total runduration, set equal to runduration, this means the last slice has a different length to the others
-        print "Time boundaries:\n" 
-        print slicearray
-        print "Start making slices:\n"
+        print("Time boundaries:\n") 
+        print(slicearray)
+        print("Start making slices:\n")
     for idx in range(len(slicearray)):
         try:
             start = slicearray[idx]; end = slicearray[idx+1]
@@ -436,7 +445,7 @@ def chopit2(rnum,output,start = 0, tslice=None,nslices = None ,sarray=[],usearra
             ConjoinWorkspaces(output+'_allslices',slicenames[-1]+'RvQ',CheckOverlapping=0)
     DeleteWorkspace(slicenames[0]+'RvQ')  
     writemap_csv(output+'_allslices',datatimes,userdirectory + output + '/'+output)
-    print "\n Trying to save the following slices: \n"
+    print("\n Trying to save the following slices: \n")
     saveslices(output+'_allslices', userdirectory+ output + '/')
 
 

--- a/reflectometry/offspec/nrkinetic.py
+++ b/reflectometry/offspec/nrkinetic.py
@@ -1,4 +1,10 @@
+from __future__ import print_function
 import offspec_red as nr
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload(nr)
 #last modified: 12/05/2016
 #by: njs
@@ -18,7 +24,7 @@ def getLog(w,log_name):
         try:
           h=mtd[w]
         except:
-          print "Can't get Workspace handle"
+          print("Can't get Workspace handle")
         #
         # Get access to SampleDetails
 	s=h.getRun().getLogData(log_name).value
@@ -37,7 +43,7 @@ def loadlatest(currentrun=None):
                 endings.append(filelist[1])
             except: pass   
     sortedendings = sorted(endings)
-    print targetname+'.n'+sortedendings[-1]
+    print(targetname+'.n'+sortedendings[-1])
     return targetname+'.n'+sortedendings[-1]
 
 def writemap_csv(wksp,times,fname):
@@ -96,7 +102,7 @@ def loaddata(rnum, path = '//ndloffspec1/L/RawData/',loadcrpt=0):
               updatefile=loadlatest(str(rnum))   
               Load(Filename='z:/'+updatefile, OutputWorkspace=str(rnum), LoaderName='LoadEventNexus', LoadMonitors=True)
             else:
-              print 'trying to load crpt snapshot'
+              print('trying to load crpt snapshot')
               Load('z:/snapshot_crpt.nxs', OutputWorkspace=str(rnum), LoaderName='LoadEventNexus', LoadMonitors=True)
         #except: 
         #    raise Exception('Could not find data')
@@ -112,10 +118,10 @@ def timeslice(rnum,btime,etime,output,loadcrpt=0):
     a1=mtd[str(rnum)]
     gr=a1.getRun()
     tamps=gr.getProtonCharge()
-    print 'tamps=',str(tamps)
+    print('tamps=',str(tamps))
     a2=mtd[str(rnum)+'_slice']
     ua=a2.getRun().getProtonCharge()
-    print 'ua=',str(ua)
+    print('ua=',str(ua))
     monnorm=mtd[str(rnum)+'_monitors']*ua/tamps
     Rebin(monnorm,'5.0,20.0,100000.0',OutputWorkspace=str(rnum)+'monreb')
     ConjoinWorkspaces(str(rnum)+'monreb',str(rnum)+'_slicereb',CheckOverlapping=False)
@@ -130,7 +136,7 @@ def chopit(rnum,btime,etime,tslice,output,slicearray=None,usearray=0,sf=1.0, sav
     
     nslice=int((etime*1.0-btime)/(tslice*1.0))
     slicenames=[]
-    print 'nslice=',str(nslice)
+    print('nslice=',str(nslice))
     if usearray==0:
         slicearray=[]
         slicearray.append(btime)
@@ -145,9 +151,9 @@ def chopit(rnum,btime,etime,tslice,output,slicearray=None,usearray=0,sf=1.0, sav
         try:
             wksp=timeslice(rnum,btime2,etime2,output,loadcrpt=loadcrpt)
             slicenames.append(wksp)
-            print slicenames
+            print(slicenames)
         except:
-            print 'time slicing failed'
+            print('time slicing failed')
             break
         nr.nrNRFn("",wksp,"0.700","LDDB05k","114","110","120",binning,"",usewkspname=1,sf=sf)
         #Rebin(wksp+"RvQ","0.011,-0.025,0.09",OutputWorkspace=wksp+"RvQ")
@@ -164,7 +170,7 @@ def chopit(rnum,btime,etime,tslice,output,slicearray=None,usearray=0,sf=1.0, sav
         datatimes.append(0.5*(slicearray[i]+slicearray[i+1]))
     writemap_csv(output+'_allslices',datatimes,'C:/everything/userthings/'+output+'/'+output)
     if save:
-        print "\n Trying to save the following slices: \n"
+        print("\n Trying to save the following slices: \n")
         saveslices(output+'_allslices','C:/everything/userthings/'+output+'/')
 
 def saveslices(inputwksp, dir = None):
@@ -173,15 +179,15 @@ def saveslices(inputwksp, dir = None):
     else:
         userdirectory = "C:/everything/userthings/"
     spectrum = 0
-    print spectrum
+    print(spectrum)
     while True:
         try:
             filename = userdirectory + inputwksp + "_" + str(spectrum) + ".dat"
             SaveAscii(inputwksp, filename, SpectrumList = [spectrum], WriteSpectrumID = False, CommentIndicator = "#", Separator = "Tab", ColumnHeader = False)
             spectrum += 1
-            print spectrum
+            print(spectrum)
         except: 
-            print "End of slices reached, this one does not exist: " + str(spectrum)
+            print("End of slices reached, this one does not exist: " + str(spectrum))
             break
      
 #k.slice_the_data(rnum=run,output=name,angle = angle, start = start, tslice = tslice, nslices = nslices ,sarray=sarray,usearray=usearray, DB = kindb, sf=kinetic_scalefactor, qlimits = qlimits, dlimits = dlimits, userdirectory = savepath,binning=binningpars,loadcrpt=0, diagnostics = False)
@@ -193,7 +199,7 @@ def slice_the_data(rnum,output,angle = None,start = 0, tslice=None,nslices = Non
     if tslice or nslices: # if tslice or nslices exist they will take precedence over slicearray
         testws = loaddata(rnum,loadcrpt=loadcrpt)
         runtotaltime = getLog(testws, 'duration')
-        print "Total runtime in seconds: " + str(runtotaltime)
+        print("Total runtime in seconds: " + str(runtotaltime))
         DeleteWorkspace(testws)
         if nslices: 
             tslice = ceil((runtotaltime - start)/(nslices))
@@ -201,9 +207,9 @@ def slice_the_data(rnum,output,angle = None,start = 0, tslice=None,nslices = Non
         while slicearray[-1] < runtotaltime:
             slicearray.append(slicearray[-1]+tslice)
         slicearray[-1] = runtotaltime # lastentry is some random number > than total runduration, set equal to runduration, this means the last slice has a different length to the others
-        print "Time boundaries:\n" 
-        print slicearray
-        print "Start making slices:\n"
+        print("Time boundaries:\n") 
+        print(slicearray)
+        print("Start making slices:\n")
     for idx in range(len(slicearray)):
         try:
             start = slicearray[idx]; end = slicearray[idx+1]
@@ -223,7 +229,7 @@ def slice_the_data(rnum,output,angle = None,start = 0, tslice=None,nslices = Non
             ConjoinWorkspaces(output+'_allslices',slicenames[-1]+'RvQ',CheckOverlapping=0)
     DeleteWorkspace(slicenames[0]+'RvQ')  
     writemap_csv(output+'_allslices',datatimes,userdirectory + output + '/'+output)
-    print "\n Trying to save the following slices: \n"
+    print("\n Trying to save the following slices: \n")
     saveslices(output+'_allslices', userdirectory+ output + '/')
 
 def _offspecslice_simple(rnum,btime,etime,qmin,qmax,output, binning,theta, DB,loadcrpt=0):
@@ -239,7 +245,7 @@ def offspecslice(rnum,qmin,qmax,output, theta,binning, DB,start = 0, tslice=None
     if tslice or nslices: # if tslice or nslices exist they will take precedence over slicearray
         testws = loaddata(rnum,loadcrpt=loadcrpt)
         runtotaltime = getLog(testws, 'duration')
-        print "Total runtime in seconds: " + str(runtotaltime)
+        print("Total runtime in seconds: " + str(runtotaltime))
         DeleteWorkspace(testws)
         if nslices: 
             tslice = ceil((runtotaltime - start)/(nslices))
@@ -247,16 +253,16 @@ def offspecslice(rnum,qmin,qmax,output, theta,binning, DB,start = 0, tslice=None
         while slicearray[-1] < runtotaltime:
             slicearray.append(slicearray[-1]+tslice)
         slicearray[-1] = runtotaltime # lastentry is some random number > than total runduration, set equal to runduration, this means the last slice has a different length to the others
-        print "Time boundaries:\n" 
-        print slicearray
-        print "Start making slices:\n"
+        print("Time boundaries:\n") 
+        print(slicearray)
+        print("Start making slices:\n")
     for idx in range(len(slicearray)):
         try:
             start = slicearray[idx]; end = slicearray[idx+1]
             datatimes.append(0.5*(start+end)) # calculate the time for this dataset for saving later
-            print "\nCreated slice "+str(datatimes[-1])
+            print("\nCreated slice "+str(datatimes[-1]))
             _offspecslice_simple(rnum, start, end, qmin, qmax, output, binning=binning, theta=theta,DB=DB,loadcrpt=loadcrpt)
         except:
-            print datatimes
+            print(datatimes)
             break
 

--- a/reflectometry/offspec/offspec_nruser.py
+++ b/reflectometry/offspec/offspec_nruser.py
@@ -30,7 +30,13 @@ runs = ["36422","36423+36424","36425-36430"]
 name is the name of your resulting workspace/file
 
 '''
+from __future__ import print_function
 import offspec_red as nr
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload(nr)
 #last modified: 12/05/2016
 #by: njs
@@ -92,7 +98,7 @@ def NRreduce(runs, name, angles=None, qlimits = None, scalefactor=None, bckg= No
     tocombine = []
     for run, angle, wname, thisspecular in zip(runs,angles,wkspnames,specular):
         try:
-            print "Runs: "+run+", angle: "+ str(angle)+", specular: "+str(thisspecular)+", name:"+name+wname
+            print("Runs: "+run+", angle: "+ str(angle)+", specular: "+str(thisspecular)+", name:"+name+wname)
             nr.nrNRFn(run,name+wname,str(angle),dbnr,thisspecular,detectorlimits['low'],detectorlimits['high'],binningpars,qgroup=nrqgroup,floodfile="",subbgd=nrbackground, diagnostics=diagnostics)
             qmin = fourpi*np.sin(angle*deg2rad)/lmax
             qmax = fourpi*np.sin(angle*deg2rad)/lmin
@@ -106,7 +112,7 @@ def NRreduce(runs, name, angles=None, qlimits = None, scalefactor=None, bckg= No
             DeleteWorkspace(name+wname+'RvQ')
                 
     tocombine =  ','.join(tocombine)
-    print tocombine
+    print(tocombine)
     try:
         nr.NRCombineDatafn(tocombine,name,"0","","","0",qlimits,str(scalefactor),"2",diagnostics=diagnostics)
         plotSpectrum([name],0,1,2)
@@ -123,7 +129,7 @@ def OFSreduce(runs, name, withpol = False, angle = None, qlimits = None, Nqx = N
     if not qlimits: qlimits = ofqlimits
     if not Nqx: Nqx = ofNqx
     if not Nqz: Nqz = ofNqz
-    print angle
+    print(angle)
     #of.DSqxqz(runs,name,angle=angle,qxqzlimits=qlimits,binning=binningpars,Nqx=Nqx,Nqz=Nqz,withpol=withpol, dspec=detectorlimits['specular'], dmin=detectorlimits['low'], dmax=detectorlimits['high'])    
     of.DSqxqz(runs,name,angle=angle,qxqzlimits=qlimits,binning=binningpars,Nqx=Nqx,Nqz=Nqz,withpol=withpol) 
  
@@ -167,10 +173,10 @@ def tr_offspec(rnum,output, nslices=None, tslice= None, sarray = [], angle=None,
         if m:
             n = re.search('^wrong{1}(.*)detnorm{1}$', name)
             if n:
-                print name
+                print(name)
                 newname = re.sub('wrong',output, name)
                 newname = re.sub('detnorm','',newname)
-                print "newname: "+newname
+                print("newname: "+newname)
                 ConvertSpectrumAxis(InputWorkspace=name, OutputWorkspace=name, Target='SignedTheta')
                 ConvertToReflectometryQ(InputWorkspace=name, OverrideIncidentTheta=True, IncidentTheta=angle, Extents=qlimits, OutputAsMDWorkspace=False, OutputWorkspace=newname+"qxqz", NumberBinsQx=ofNqx, NumberBinsQz=ofNqz,OutputVertexes="somevertices")
                 CloneWorkspace(name,OutputWorkspace=newname+'detnorm')

--- a/reflectometry/offspec/offspec_offspec.py
+++ b/reflectometry/offspec/offspec_offspec.py
@@ -1,4 +1,10 @@
+from __future__ import print_function
 import offspec_red as nr
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload(nr)
 #last modified:12/05/2016 
 #by: njs
@@ -20,7 +26,7 @@ def getLog(w,log_name):
         try:
           h=mtd[w]
         except:
-          print "Can't get Workspace handle"
+          print("Can't get Workspace handle")
         #
         # Get access to SampleDetails
 	s=h.getRun().getLogData(log_name).value
@@ -104,7 +110,7 @@ def loadlatest(currentrun=None):
                 endings.append(filelist[1])
             except: pass   
     sortedendings = sorted(endings)
-    print targetname+'.n'+sortedendings[-1]
+    print(targetname+'.n'+sortedendings[-1])
     return targetname+'.n'+sortedendings[-1]
 
 def loaddata(rnum, path = '//ndloffspec1/L/RawData/',loadcrpt=0):
@@ -116,7 +122,7 @@ def loaddata(rnum, path = '//ndloffspec1/L/RawData/',loadcrpt=0):
               updatefile=loadlatest(str(rnum))   
               Load(Filename='z:/'+updatefile, OutputWorkspace=str(rnum), LoaderName='LoadEventNexus', LoadMonitors=True)
             else:
-              print 'trying to load crpt snapshot'
+              print('trying to load crpt snapshot')
               Load('z:/snapshot_crpt.nxs', OutputWorkspace=str(rnum), LoaderName='LoadEventNexus', LoadMonitors=True)
         #except: 
         #    raise Exception('Could not find data')
@@ -257,8 +263,11 @@ def QxQzcuts(name, qzmin=None, qzmax=None,plot=False):
         yscale('log')
 
 
-def offspecPlot(wksp, (xmin, xmax), (ymin,ymax), (zmin,zmax),logscale='z'):
+def offspecPlot(wksp, xrange, yrange, zrange,logscale='z'):
     
+    (xmin, xmax) = xrange
+    (ymin,ymax) = yrange
+    (zmin,zmax) = zrange
     p = plot2D(wksp)
     l=p.activeLayer()
     l.setScale(0, ymin, ymax)

--- a/reflectometry/offspec/offspec_pnruser.py
+++ b/reflectometry/offspec/offspec_pnruser.py
@@ -52,7 +52,13 @@ OFSreduce(runs, name, withpol = 'pnr')
 Reduces offspcular data
 
 '''
+from __future__ import print_function
 import offspec_red as nr
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload(nr)
 #last modified: 12/05/2016
 #by: njs
@@ -103,12 +109,12 @@ deg2rad = np.pi/180
 
 def print_calibrations():
     calibrations = nr.PolarisationCalibration.get_calibrations()
-    print "========================================\n"
-    for each in calibrations.keys():
-        print each + ":  "+calibrations[each].comment+"\n"
-    print "========================================\n"
-    print "Current calibration: "+nr.PolarisationCalibration.current.name
-    print "========================================\n"
+    print("========================================\n")
+    for each in list(calibrations.keys()):
+        print(each + ":  "+calibrations[each].comment+"\n")
+    print("========================================\n")
+    print("Current calibration: "+nr.PolarisationCalibration.current.name)
+    print("========================================\n")
     
 
 def PNRreduce(runs, name, angles=None, qlimits = None, scalefactor=None, bckg = None, specular = None, diagnostics = False):
@@ -126,7 +132,7 @@ def PNRreduce(runs, name, angles=None, qlimits = None, scalefactor=None, bckg = 
     tocombineup = ""
     tocombinedown = ""
     for run, angle, wname, thisspecular in zip(runs,angles,wkspnames,specular):
-        print "Runs: "+run+", angle: "+ str(angle)+", specular:"+str(thisspecular)+", name:"+name+str(wname)
+        print("Runs: "+run+", angle: "+ str(angle)+", specular:"+str(thisspecular)+", name:"+name+str(wname))
         nr.nrPNRFn(run,name+wname,str(angle),dbpnr,thisspecular,detectorlimits['low'],detectorlimits['high'],binningpars,floodfile="",qgroup=pnrqgroup,PNRwithPA=False,pnums=["1","2"],doCorrs=True, calibration = calibration, subbgd=bckg, diagnostics=diagnostics)
         qmin = fourpi*np.sin(angle*deg2rad)/lmax
         qmax = fourpi*np.sin(angle*deg2rad)/lmin
@@ -135,7 +141,7 @@ def PNRreduce(runs, name, angles=None, qlimits = None, scalefactor=None, bckg = 
         tocombinedown = tocombinedown+name+wname+"normcorrRvQ_2,"
     tocombineup = tocombineup[:-1]
     tocombinedown = tocombinedown[:-1]
-    print tocombineup, tocombinedown
+    print(tocombineup, tocombinedown)
     try:
         a1=nr.NRCombineDatafn(tocombineup,name+"U","0","","","0",qlimits,str(scalefactor),"2",diagnostics=diagnostics)
         nr.NRCombineDatafn(tocombinedown,name+"D","2",a1[0],a1[1],"0",qlimits,str(scalefactor),"2",diagnostics=diagnostics)
@@ -163,9 +169,9 @@ def PAreduce(runs, name, angles=None, qlimits = None, scalefactor=None, bckg = N
 
     wkspnames = ('low','mid', 'high', 'veryhigh', 'extremelyhigh', 'toomany', 'waytoomany', '8', '9', '10')
     tocombineuu, tocombineud, tocombinedu, tocombinedd  = "", "", "", ""
-    print "Angles used: "+str(angles)
+    print("Angles used: "+str(angles))
     for run, angle, wname, thisspecular in zip(runs,angles,wkspnames, specular):
-        print "Runs: "+run+", angle: "+ str(angle)+", specular:"+str(thisspecular)+", name:"+name+str(wname)
+        print("Runs: "+run+", angle: "+ str(angle)+", specular:"+str(thisspecular)+", name:"+name+str(wname))
         nr.nrPNRFn(run,name+wname,str(angle),dbpa,thisspecular,str(detectorlimits['low']),str(detectorlimits['high']),binningpars,floodfile="",qgroup=paqgroup,PNRwithPA=True,pnums=["1","2","3","4"],doCorrs=True, calibration = calibration, subbgd=bckg, diagnostics=diagnostics)
         qmin = fourpi*np.sin(angle*deg2rad)/lmax
         qmax = fourpi*np.sin(angle*deg2rad)/lmin
@@ -185,7 +191,7 @@ def PAreduce(runs, name, angles=None, qlimits = None, scalefactor=None, bckg = N
     tocombineud = tocombineud[:-1]
     tocombinedu = tocombinedu[:-1]
     tocombinedd = tocombinedd[:-1]
-    print tocombineuu+tocombineud+tocombinedu+tocombinedd
+    print(tocombineuu+tocombineud+tocombinedu+tocombinedd)
     try:
         a1=nr.NRCombineDatafn(tocombineuu,name+"UU","0","","","0",qlimits,str(scalefactor),"2", diagnostics=diagnostics)
         nr.NRCombineDatafn(tocombineud,name+"UD","2",a1[0],a1[1],"0",qlimits,str(scalefactor),"2",diagnostics=diagnostics)
@@ -221,7 +227,7 @@ def OFSreduce(runs, name, withpol = 'pnr', angle = None, qlimits = None, Nqx = N
     if not qlimits: qlimits = ofqlimits
     if not Nqx: Nqx = ofsNqx
     if not Nqz: Nqz = ofsNqz
-    print angle
+    print(angle)
     of.DSqxqz(runs,name,angle=angle,qxqzlimits=qlimits,binning=binningpars,Nqx=Nqx,Nqz=Nqz,withpol=withpol)    
     
  

--- a/sans/BILBY/reducer_2017_08_26.py
+++ b/sans/BILBY/reducer_2017_08_26.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from mantid import *
 import numpy as np
 import numpy as np
@@ -5,6 +6,11 @@ import os, csv, math
 from mantid.kernel import Logger
 
 import BilbyCustomFunctions_Reduction
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload (BilbyCustomFunctions_Reduction)
 
 ansto_logger = Logger("AnstoDataReduction")
@@ -120,7 +126,7 @@ except:
 reduce_2D_input = current_reduction_settings[0]["reduce_2D"].lower()
 reduce_2D = BilbyCustomFunctions_Reduction.string_boolean(reduce_2D_input)
 if reduce_2D: 
-    print "2D reduction is performing. Q interval and number of points are taking into account; Q-binning intervals are ignored."
+    print("2D reduction is performing. Q interval and number of points are taking into account; Q-binning intervals are ignored.")
     try:
         number_data_points_2D = float(current_reduction_settings[0]["2D_number_data_points"]) # for 2D Q-binning is not intuitive, hence only number of points is needed
     except:
@@ -167,13 +173,13 @@ for current_file in files_to_reduce:
         external_mode = True #This is needed for old files, where the ToF/mono mode value has not been recorded
 
     if (not external_mode): # Internal frame source has been used during data collection; it is not always NVS only, one can have both, NVS and choppers running for this mode
-        print "Internal frame source. Binning range is taken from the sample scattering data." 
+        print("Internal frame source. Binning range is taken from the sample scattering data.") 
         binning_wavelength_ini = (ws_sam.readX(0)[0], ws_sam.readX(0)[ws_sam.blocksize()] - ws_sam.readX(0)[0], ws_sam.readX(0)[ws_sam.blocksize()])            
         binning_wavelength_transmission = binning_wavelength_ini      
         if wavelength_intervals:
             wavelength_intervals = False
-            print "NVS: monochromatic mode"
-            print "There is no sense to reduce monochromatic data on multiple wavelength; \"wavelength_intervals\" value changed to False."
+            print("NVS: monochromatic mode")
+            print("There is no sense to reduce monochromatic data on multiple wavelength; \"wavelength_intervals\" value changed to False.")
     else: # important for the case when NVS data is being analysed first, ie to be able to come back to the whole range & wavelength slices, if needed
             binning_wavelength_ini = binning_wavelength_ini_original
             binning_wavelength_transmission = binning_wavelength_transmission_original
@@ -200,7 +206,7 @@ for current_file in files_to_reduce:
     att_pos = float(ws_tranSam.run().getProperty("att_pos").value)
     
     scale = BilbyCustomFunctions_Reduction.AttenuationCorrection(att_pos, data_before_May_2016)
-    print "scale, aka attenuation factor", scale
+    print("scale, aka attenuation factor", scale)
        
     thickness = current_file["thickness [cm]"]
 
@@ -272,7 +278,7 @@ for current_file in files_to_reduce:
             n_2D = output_workspace.name() + '.png'
             SavePlot = os.path.join(os.path.expanduser(reduced_files_path), n_2D)
             plot2Dgraph.export(SavePlot)
-            print "2D File Exists:", os.path.exists(SavePlot)
+            print("2D File Exists:", os.path.exists(SavePlot))
             SaveNxs = os.path.join(os.path.expanduser(reduced_files_path), output_workspace.name() + '.nxs')
             SaveNISTDAT(output_workspace.name(), SaveNxs)
             if not plot_2D: plot2Dgraph.close() # is there more elegant way to do it? Problem is that plot2Dgraph creates and plot the graph file at the same time...
@@ -286,8 +292,8 @@ for current_file in files_to_reduce:
             n_1D = output_workspace.name() +".dat"       # 1D output file; name based on "base_output_name" construct
             savefile = os.path.join(os.path.expanduser(reduced_files_path), n_1D)          # setting up full path
             SaveAscii(InputWorkspace = output_workspace, Filename = savefile, WriteXError = True, WriteSpectrumID = False, Separator = "CSV") #saving file
-            print savefile
-            print "1D File Exists:", os.path.exists(savefile)            
+            print(savefile)
+            print("1D File Exists:", os.path.exists(savefile))            
 
 ### ================================================================================
 # - add subtraction of the background -- later

--- a/sans/BILBY/subtraction_final.py
+++ b/sans/BILBY/subtraction_final.py
@@ -1,8 +1,14 @@
 ## SECOND ONE
+from __future__ import print_function
 
 from mantid.api import *
 import csv
 import BilbyCustomFunctions_Reduction
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload (BilbyCustomFunctions_Reduction)
 
 #============================================================================================================================================#
@@ -75,10 +81,10 @@ for current_file in files_to_subtract:
     header_line.append(['background file name: ' + background_file])
     header_line.append(['Constant to subtract from sample scattering = ' + str(scale_subtr)])
     header_line.append(['Background multiplier = ' + str(scale_mult)])
-    print header_line
+    print(header_line)
 # writing header in the file
     for line in header_line:
-        print line
+        print(line)
         with open(sub_file_output, 'ab') as f_out:
             wr = csv.writer(f_out, delimiter=',', lineterminator='\n')
             wr.writerow(line)

--- a/sans/Bilby_old/reducer_generic_final.py
+++ b/sans/Bilby_old/reducer_generic_final.py
@@ -1,9 +1,15 @@
+from __future__ import print_function
 from mantid import *
 import numpy as np
 import os, csv, math
 from mantid.kernel import Logger
 
 import BilbyCustomFunctions_Reduction
+if sys.version_info > (3,):
+    if sys.version_info < (3,4):
+        from imp import reload
+    else:
+        from importlib import reload
 reload (BilbyCustomFunctions_Reduction)
 
 ansto_logger = Logger("AnstoDataReduction")
@@ -119,7 +125,7 @@ except:
 reduce_2D_input = current_reduction_settings[0]["reduce_2D"].lower()
 reduce_2D = BilbyCustomFunctions_Reduction.string_boolean(reduce_2D_input)
 if reduce_2D: 
-    print "2D reduction is performing. Q interval and number of points are taking into account; Q-binning intervals are ignored."
+    print("2D reduction is performing. Q interval and number of points are taking into account; Q-binning intervals are ignored.")
     try:
         number_data_points_2D = float(current_reduction_settings[0]["2D_number_data_points"]) # for 2D Q-binning is not intuitive, hence only number of points is needed
     except:
@@ -161,13 +167,13 @@ for current_file in files_to_reduce:
         external_mode = True #This is needed for old files, where the ToF/mono mode value has not been recorded
 
     if (not external_mode): # Internal frame source has been used during data collection; it is not always NVS only, one can have both, NVS and choppers running for this mode
-        print "Internal frame source. Binning range is taken from the sample scattering data." 
+        print("Internal frame source. Binning range is taken from the sample scattering data.") 
         binning_wavelength_ini = (ws_sam.readX(0)[0], ws_sam.readX(0)[ws_sam.blocksize()] - ws_sam.readX(0)[0], ws_sam.readX(0)[ws_sam.blocksize()])            
         binning_wavelength_transmission = binning_wavelength_ini      
         if wavelength_intervals:
             wavelength_intervals = False
-            print "NVS: monochromatic mode"
-            print "There is no sense to reduce monochromatic data on multiple wavelength; \"wavelength_intervals\" value changed to False."
+            print("NVS: monochromatic mode")
+            print("There is no sense to reduce monochromatic data on multiple wavelength; \"wavelength_intervals\" value changed to False.")
     else: # important for the case when NVS data is being analysed first, ie to be able to come back to the whole range & wavelength slices, if needed
             binning_wavelength_ini = binning_wavelength_ini_original
             binning_wavelength_transmission = binning_wavelength_transmission_original
@@ -194,7 +200,7 @@ for current_file in files_to_reduce:
     att_pos = float(ws_tranSam.run().getProperty("att_pos").value)
     
     scale = BilbyCustomFunctions_Reduction.AttenuationCorrection(att_pos, data_before_May_2016)
-    print "scale, aka attenuation factor", scale
+    print("scale, aka attenuation factor", scale)
        
     thickness = current_file["thickness [cm]"]
 
@@ -223,7 +229,7 @@ for current_file in files_to_reduce:
  
     # wavelenth intervals: building  binning_wavelength list 
     binning_wavelength, n = BilbyCustomFunctions_Reduction.wavelengh_slices(wavelength_intervals, binning_wavelength_ini, wav_delta)
-    print "final wavelengths slices list", binning_wavelength
+    print("final wavelengths slices list", binning_wavelength)
     
 ###############################################################
 # By now we know how many wavelengths bins we have, so shall run Q1D n times
@@ -263,7 +269,7 @@ for current_file in files_to_reduce:
             n_2D = output_workspace.name() + '.png'
             SavePlot = os.path.join(os.path.expanduser(reduced_files_path), n_2D)
             plot2Dgraph.export(SavePlot)
-            print "2D File Exists:", os.path.exists(SavePlot)
+            print("2D File Exists:", os.path.exists(SavePlot))
             SaveNxs = os.path.join(os.path.expanduser(reduced_files_path), output_workspace.name() + '.nxs')
             SaveNISTDAT(output_workspace.name(), SaveNxs)
             if not plot_2D: plot2Dgraph.close() # is there more elegant way to do it? Problem is that plot2Dgraph creates and plot the graph file at the same time...
@@ -277,8 +283,8 @@ for current_file in files_to_reduce:
             n_1D = output_workspace.name() +".dat"       # 1D output file; name based on "base_output_name" construct
             savefile = os.path.join(os.path.expanduser(reduced_files_path), n_1D)          # setting up full path
             SaveAscii(InputWorkspace = output_workspace, Filename = savefile, WriteXError = True, WriteSpectrumID = False, Separator = "CSV") #saving file
-            print savefile
-            print "1D File Exists:", os.path.exists(savefile)            
+            print(savefile)
+            print("1D File Exists:", os.path.exists(savefile))            
 
 ### ================================================================================
 # - add subtraction of the background -- later

--- a/system/scriptrepositoryparser.py
+++ b/system/scriptrepositoryparser.py
@@ -40,6 +40,7 @@ Created on Wed Mar  6 09:05:08 2013
 
 @author: gesner
 """
+from __future__ import print_function
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import json
@@ -48,7 +49,7 @@ from os.path import join
 import time
 import compiler
 import sys
-import commands
+import subprocess
 import re
 
 re_default_author = re.compile('Author: (?P<author>.+) <(?P<email>.+)>')
@@ -192,7 +193,7 @@ def get_description(path):
 
 def get_author(path):
     try:
-        output = commands.getstatusoutput("git log -1 "+path)[1]
+        output = subprocess.getstatusoutput("git log -1 "+path)[1]
         spec_m = re.search(re_signed_author,output)
         if spec_m:
             return spec_m.group('author')

--- a/system/scriptrepositoryparser.py
+++ b/system/scriptrepositoryparser.py
@@ -40,7 +40,6 @@ Created on Wed Mar  6 09:05:08 2013
 
 @author: gesner
 """
-from __future__ import print_function
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import json
@@ -49,7 +48,10 @@ from os.path import join
 import time
 import compiler
 import sys
-import subprocess
+if sys.version_info < (2,7):
+	import commands as subprocess
+else:
+	import subprocess
 import re
 
 re_default_author = re.compile('Author: (?P<author>.+) <(?P<email>.+)>')


### PR DESCRIPTION
Manual changes (on top of 2to3.py changes) to a subset of files not changed in branch 26977_Python2to3_compatibility - see pull request #4 that must be merged before this.

Changes here include:
(1)  importing library tkinter (different name in python 2.x)
(2) importing importlib.reload as reload if python 3
(3) Replacing input with six.moves.input (note this only applies to one file which used input() instead of raw_input() - the latter being what I think was intended if it was being run on python 2.x).
(4)  Tuples in some function declarations changed with sensible argument names
(5) importing of either commands or subprocess library depending on python version

Things to note/Changes not made:
(1) Note assertEqual and assertEquals are equivalent in python 2.x
(2) In python 3 all imports must be absolute, but in the case where importing classes etc. from files in the same directory when an ```__init__.py``` file is present in that directory it is acceptable to have e.g. ```from file_in_this_dir import myClass``` (as opposed to ```from .file_in_this_dir import myClass```).