### PR TITLE
Updated import paths related to InstrumentArrayConverter and PeakData in script repository

### DIFF
--- a/diffraction/sxd_bk2bk_exp_coef.py
+++ b/diffraction/sxd_bk2bk_exp_coef.py
@@ -2,7 +2,7 @@
 from mantid.simpleapi import *
 import matplotlib.pyplot as plt
 import numpy as np
-from IntegratePeaksSkew import InstrumentArrayConverter, PeakData
+from plugins.algorithms.peakdata_utils import InstrumentArrayConverter, PeakData
 from scipy.optimize import minimize, curve_fit
 from mantid.api import FunctionFactory
 


### PR DESCRIPTION
Updated the import path for `InstrumentArrayConverter` and `PeakData` classes after refactoring them into a utility module located at `plugins.algorithms.peakdata_utils`