### PR TITLE
Add GitHub token to indexing workflow steps

### DIFF
--- a/.github/workflows/indexing.yml
+++ b/.github/workflows/indexing.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          github_token: ${{ secrets.INDEXING }}
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -25,3 +27,4 @@ jobs:
           commit_message: Updating repository index JSON file
           commit_options: '--no-verify'
           file_pattern: './repository.json'
+          github_token: ${{ secrets.INDEXING }}


### PR DESCRIPTION
Following branch protection rules being enabled, this GitHub Action requires an access token to work.

I don't think this can be tested without merging in the PR